### PR TITLE
Analytics Draft

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,38 +1,57 @@
 module.exports = {
   siteMetadata: {
-    title: 'Gatsby + Netlify CMS Starter',
+    title: "Gatsby + Netlify CMS Starter"
   },
   plugins: [
-    'gatsby-plugin-react-helmet',
-    'gatsby-plugin-sass',
+    "gatsby-plugin-react-helmet",
+    "gatsby-plugin-sass",
     {
-      resolve: 'gatsby-source-filesystem',
+      resolve: "gatsby-source-filesystem",
       options: {
         path: `${__dirname}/src/pages`,
-        name: 'pages',
-      },
+        name: "pages"
+      }
     },
     {
-      resolve: 'gatsby-source-filesystem',
+      resolve: "gatsby-source-filesystem",
       options: {
         path: `${__dirname}/src/img`,
-        name: 'images',
-      },
+        name: "images"
+      }
     },
-    'gatsby-plugin-sharp',
-    'gatsby-transformer-sharp',
+    "gatsby-plugin-sharp",
+    "gatsby-transformer-sharp",
     {
-      resolve: 'gatsby-transformer-remark',
+      resolve: "gatsby-transformer-remark",
       options: {
-        plugins: [],
-      },
+        plugins: []
+      }
     },
     {
-      resolve: 'gatsby-plugin-netlify-cms',
+      resolve: "gatsby-plugin-netlify-cms",
       options: {
-        modulePath: `${__dirname}/src/cms/cms.js`,
-      },
+        modulePath: `${__dirname}/src/cms/cms.js`
+      }
     },
-    'gatsby-plugin-netlify', // make sure to keep it last in the array
-  ],
-}
+    {
+      resolve: `gatsby-plugin-segment-js`,
+      options: {
+        // your segment write key for your production environment
+        // when process.env.NODE_ENV === 'production'
+        // required; non-empty string
+        prodKey: `eb2jgDZTjAmBwOPzVfUkSB1WIaAsAayF`,
+
+        // if you have a development env for your segment account, paste that key here
+        // when process.env.NODE_ENV === 'development'
+        // optional; non-empty string
+        devKey: `eb2jgDZTjAmBwOPzVfUkSB1WIaAsAayF`,
+
+        // whether you want to include analytics.page()
+        // optional; boolean that defaults to true
+        // if false, then don't forget to manually add it to your codebase manually!
+        trackPage: true
+      }
+    },
+    "gatsby-plugin-netlify" // make sure to keep it last in the array
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "7.0.68"
       }
     },
     "@types/history": {
@@ -65,7 +65,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.7.tgz",
       "integrity": "sha512-tHpSs7HMyjnpyfzka1G0pYh7rBNdpwGgcIDT4vfV6jUaR69yOHo/vNH2H+d9iYHo9xnX4qDe7UalPe9HiGRkLw==",
       "requires": {
-        "csstype": "^2.2.0"
+        "csstype": "2.5.6"
       }
     },
     "@types/react-router": {
@@ -73,8 +73,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.30.tgz",
       "integrity": "sha512-zWt5RpWy7x7semeBIHqLZ31A1Tle0jb3R/KD2wguZqO43DjP4n8kYsH7UIpve6I4hzlSObnoIieDcp5qfyKwaQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
+        "@types/history": "4.7.0",
+        "@types/react": "16.4.7"
       }
     },
     "@types/react-router-dom": {
@@ -82,9 +82,9 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.3.0.tgz",
       "integrity": "sha512-vaq+nVUGyMnIhAl+svKHmfqhCoCNe5lf1UWmvVcsBlAcX0kznF25711DNFQ7B8/QZ+ZF1zzGq1dIi9bzxIu85w==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/history": "4.7.0",
+        "@types/react": "16.4.7",
+        "@types/react-router": "4.0.30"
       }
     },
     "@types/tmp": {
@@ -107,7 +107,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.19",
         "negotiator": "0.6.1"
       }
     },
@@ -131,10 +131,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "align-text": {
@@ -142,9 +142,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alphanum-sort": {
@@ -167,7 +167,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "ansi-escapes": {
@@ -213,8 +213,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "aproba": {
@@ -232,7 +232,7 @@
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "requires": {
-        "file-type": "^3.1.0"
+        "file-type": "3.9.0"
       },
       "dependencies": {
         "file-type": {
@@ -247,8 +247,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "arg": {
@@ -261,7 +261,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -269,7 +269,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -334,7 +334,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -362,7 +362,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "asn1.js": {
@@ -370,9 +370,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -413,7 +413,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
@@ -451,12 +451,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
-        "browserslist": "^1.7.6",
-        "caniuse-db": "^1.0.30000634",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.2.16",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000872",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -464,8 +464,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000872",
+            "electron-to-chromium": "1.3.55"
           }
         }
       }
@@ -485,21 +485,21 @@
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.11.0",
-        "convert-source-map": "^1.5.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^4.17.4",
-        "output-file-sync": "^1.1.2",
-        "path-is-absolute": "^1.0.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6",
-        "v8flags": "^2.1.1"
+        "babel-core": "6.26.3",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.16.0",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "commander": {
@@ -514,9 +514,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -524,25 +524,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       }
     },
     "babel-generator": {
@@ -550,14 +550,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "babel-helper-bindify-decorators": {
@@ -565,9 +565,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -575,9 +575,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -585,9 +585,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "esutils": "^2.0.2"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -595,10 +595,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -606,10 +606,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -617,9 +617,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -627,10 +627,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -638,11 +638,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -650,8 +650,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -659,8 +659,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -668,8 +668,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -677,9 +677,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -687,11 +687,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -699,12 +699,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -712,8 +712,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-loader": {
@@ -721,10 +721,10 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "requires": {
-        "find-cache-dir": "^0.1.1",
-        "loader-utils": "^0.2.16",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.0.1"
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "babel-messages": {
@@ -732,7 +732,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -745,7 +745,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -824,7 +824,7 @@
       "integrity": "sha1-Uhx4LTVkRJHJeepoPopeHK/wukI=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-async-generator-functions": {
@@ -832,9 +832,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -842,9 +842,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-cjs-system-wrapper": {
@@ -853,7 +853,7 @@
       "integrity": "sha1-vXSUd1KJQk/0k7btRV3klb1xuh0=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -861,9 +861,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -871,10 +871,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -882,11 +882,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -894,8 +894,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "requires": {
-        "babel-plugin-syntax-do-expressions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-do-expressions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -903,7 +903,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -911,7 +911,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -919,11 +919,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -931,15 +931,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -947,8 +947,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -956,7 +956,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -964,8 +964,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -973,7 +973,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -981,9 +981,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -991,7 +991,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -999,9 +999,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1009,10 +1009,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1020,9 +1020,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1030,9 +1030,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1040,8 +1040,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1049,12 +1049,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1062,8 +1062,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1071,7 +1071,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1079,9 +1079,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1089,7 +1089,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1097,7 +1097,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1105,9 +1105,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-es3-member-expression-literals": {
@@ -1115,7 +1115,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
       "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es3-property-literals": {
@@ -1123,7 +1123,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
       "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1131,9 +1131,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -1141,8 +1141,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1150,8 +1150,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -1159,8 +1159,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "requires": {
-        "babel-plugin-syntax-function-bind": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-function-bind": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-global-system-wrapper": {
@@ -1169,7 +1169,7 @@
       "integrity": "sha1-lI3X0p/CFEfjm9NEfy3rx/L3Oqw=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-object-assign": {
@@ -1177,7 +1177,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
       "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1185,8 +1185,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -1194,7 +1194,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -1202,9 +1202,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "^6.24.1",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-react-jsx": "6.26.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -1212,8 +1212,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -1221,8 +1221,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1230,7 +1230,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1238,8 +1238,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-system-register": {
@@ -1253,9 +1253,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1270,36 +1270,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -1307,30 +1307,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-fbjs": {
@@ -1338,34 +1338,34 @@
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.2.0.tgz",
       "integrity": "sha512-jj0KFJDioYZMtPtZf77dQuU+Ad/1BtN0UnAYlHDa8J8f4tGXr3YrPoJImD5MdueaOPeN/jUdrCgu330EfXr0XQ==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-plugin-syntax-flow": "^6.8.0",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-        "babel-plugin-transform-class-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-        "babel-plugin-transform-es2015-classes": "^6.8.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.8.0",
-        "babel-plugin-transform-es2015-for-of": "^6.8.0",
-        "babel-plugin-transform-es2015-function-name": "^6.8.0",
-        "babel-plugin-transform-es2015-literals": "^6.8.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-        "babel-plugin-transform-es2015-object-super": "^6.8.0",
-        "babel-plugin-transform-es2015-parameters": "^6.8.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.8.0",
-        "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-        "babel-plugin-transform-es3-property-literals": "^6.8.0",
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-plugin-transform-object-rest-spread": "^6.8.0",
-        "babel-plugin-transform-react-display-name": "^6.8.0",
-        "babel-plugin-transform-react-jsx": "^6.8.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es3-member-expression-literals": "6.22.0",
+        "babel-plugin-transform-es3-property-literals": "6.22.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1"
       }
     },
     "babel-preset-flow": {
@@ -1373,7 +1373,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
       }
     },
     "babel-preset-react": {
@@ -1381,12 +1381,12 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.3.13",
-        "babel-plugin-transform-react-display-name": "^6.23.0",
-        "babel-plugin-transform-react-jsx": "^6.24.1",
-        "babel-plugin-transform-react-jsx-self": "^6.22.0",
-        "babel-plugin-transform-react-jsx-source": "^6.22.0",
-        "babel-preset-flow": "^6.23.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-preset-flow": "6.23.0"
       }
     },
     "babel-preset-stage-0": {
@@ -1394,9 +1394,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "requires": {
-        "babel-plugin-transform-do-expressions": "^6.22.0",
-        "babel-plugin-transform-function-bind": "^6.22.0",
-        "babel-preset-stage-1": "^6.24.1"
+        "babel-plugin-transform-do-expressions": "6.22.0",
+        "babel-plugin-transform-function-bind": "6.22.0",
+        "babel-preset-stage-1": "6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1404,9 +1404,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1414,10 +1414,10 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1425,11 +1425,11 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1437,13 +1437,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1451,8 +1451,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1460,11 +1460,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -1472,15 +1472,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -1488,10 +1488,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1519,13 +1519,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1533,7 +1533,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1541,7 +1541,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1549,7 +1549,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1557,9 +1557,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1604,13 +1604,13 @@
       "resolved": "https://registry.npmjs.org/bash-glob/-/bash-glob-1.0.2.tgz",
       "integrity": "sha512-E0TTxH9T/tklSXt5R5X0zwxjW56su2VIE+sAruXbd8AtMjYZxtvioybVdptbRk0/0Nvdz0TVVShKhN9sH5dMpg==",
       "requires": {
-        "async-each": "^1.0.1",
-        "bash-path": "^1.0.1",
-        "component-emitter": "^1.2.1",
-        "cross-spawn": "^5.1.0",
-        "extend-shallow": "^2.0.1",
-        "is-extglob": "^2.1.1",
-        "is-glob": "^4.0.0"
+        "async-each": "1.0.1",
+        "bash-path": "1.0.3",
+        "component-emitter": "1.2.1",
+        "cross-spawn": "5.1.0",
+        "extend-shallow": "2.0.1",
+        "is-extglob": "2.1.1",
+        "is-glob": "4.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1618,7 +1618,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-extglob": {
@@ -1631,7 +1631,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -1641,8 +1641,8 @@
       "resolved": "https://registry.npmjs.org/bash-path/-/bash-path-1.0.3.tgz",
       "integrity": "sha512-mGrYvOa6yTY/qNCiZkPFJqWmODK68y6kmVRAJ1NNbWlNoJrUrsFxu7FU2EKg7gbrer6ttrKkF2s/E/lhRy7/OA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "is-windows": "^1.0.1"
+        "arr-union": "3.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "batch": {
@@ -1656,7 +1656,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1677,9 +1677,9 @@
       "resolved": "https://registry.npmjs.org/better-queue/-/better-queue-3.8.10.tgz",
       "integrity": "sha512-e3gwNZgDCnNWl0An0Tz6sUjKDV9m6aB+K9Xg//vYeo8+KiH8pWhLFxkawcXhm6FpM//GfD9IQv/kmvWCAVVpKA==",
       "requires": {
-        "better-queue-memory": "^1.0.1",
-        "node-eta": "^0.9.0",
-        "uuid": "^3.0.0"
+        "better-queue-memory": "1.0.2",
+        "node-eta": "0.9.0",
+        "uuid": "3.3.2"
       }
     },
     "better-queue-memory": {
@@ -1702,13 +1702,13 @@
       "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
       "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
       "requires": {
-        "archive-type": "^3.0.1",
-        "decompress": "^3.0.0",
-        "download": "^4.1.2",
-        "exec-series": "^1.0.0",
-        "rimraf": "^2.2.6",
-        "tempfile": "^1.0.0",
-        "url-regex": "^3.0.0"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "download": "4.4.3",
+        "exec-series": "1.0.3",
+        "rimraf": "2.6.2",
+        "tempfile": "1.1.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "tempfile": {
@@ -1716,8 +1716,8 @@
           "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
           "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
           "requires": {
-            "os-tmpdir": "^1.0.0",
-            "uuid": "^2.0.1"
+            "os-tmpdir": "1.0.2",
+            "uuid": "2.0.3"
           }
         },
         "uuid": {
@@ -1732,7 +1732,7 @@
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
       "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
       "requires": {
-        "executable": "^1.0.0"
+        "executable": "1.1.0"
       }
     },
     "bin-version": {
@@ -1740,7 +1740,7 @@
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
       "requires": {
-        "find-versions": "^1.0.0"
+        "find-versions": "1.2.1"
       }
     },
     "bin-version-check": {
@@ -1748,10 +1748,10 @@
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
       "requires": {
-        "bin-version": "^1.0.0",
-        "minimist": "^1.1.0",
-        "semver": "^4.0.3",
-        "semver-truncate": "^1.0.0"
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
       },
       "dependencies": {
         "minimist": {
@@ -1771,12 +1771,12 @@
       "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
       "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
       "requires": {
-        "bin-check": "^2.0.0",
-        "bin-version-check": "^2.1.0",
-        "download": "^4.0.0",
-        "each-async": "^1.1.1",
-        "lazy-req": "^1.0.0",
-        "os-filter-obj": "^1.0.0"
+        "bin-check": "2.0.0",
+        "bin-version-check": "2.1.0",
+        "download": "4.4.3",
+        "each-async": "1.1.1",
+        "lazy-req": "1.1.0",
+        "os-filter-obj": "1.0.3"
       }
     },
     "binary-extensions": {
@@ -1789,8 +1789,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blob": {
@@ -1803,7 +1803,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "bluebird": {
@@ -1827,15 +1827,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "boolbase": {
@@ -1848,7 +1848,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       },
       "dependencies": {
         "hoek": {
@@ -1868,13 +1868,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1882,7 +1882,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -1890,9 +1890,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -1905,7 +1905,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1915,7 +1915,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1924,9 +1924,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -1939,12 +1939,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -1952,9 +1952,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -1962,10 +1962,10 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1973,8 +1973,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1982,13 +1982,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
@@ -1996,7 +1996,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -2004,8 +2004,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
+        "caniuse-lite": "1.0.30000865",
+        "electron-to-chromium": "1.3.55"
       }
     },
     "bser": {
@@ -2013,7 +2013,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -2021,9 +2021,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -2031,8 +2031,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2071,10 +2071,10 @@
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "requires": {
-        "file-type": "^3.1.0",
-        "readable-stream": "^2.0.2",
-        "uuid": "^2.0.1",
-        "vinyl": "^1.0.0"
+        "file-type": "3.9.0",
+        "readable-stream": "2.3.6",
+        "uuid": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "file-type": {
@@ -2119,15 +2119,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2152,8 +2152,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -2166,8 +2166,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2182,10 +2182,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
-        "browserslist": "^1.3.6",
-        "caniuse-db": "^1.0.30000529",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000872",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2193,8 +2193,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000872",
+            "electron-to-chromium": "1.3.55"
           }
         }
       }
@@ -2224,10 +2224,10 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "requires": {
-        "get-proxy": "^1.0.1",
-        "is-obj": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "tunnel-agent": "^0.4.0"
+        "get-proxy": "1.1.0",
+        "is-obj": "1.0.1",
+        "object-assign": "3.0.0",
+        "tunnel-agent": "0.4.3"
       },
       "dependencies": {
         "object-assign": {
@@ -2252,8 +2252,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chain-function": {
@@ -2266,11 +2266,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "character-entities": {
@@ -2308,22 +2308,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       },
       "dependencies": {
         "domhandler": {
@@ -2331,7 +2331,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -2339,12 +2339,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -2354,15 +2354,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -2375,7 +2375,7 @@
       "resolved": "https://registry.npmjs.org/chunk-manifest-webpack-plugin/-/chunk-manifest-webpack-plugin-0.1.0.tgz",
       "integrity": "sha1-YThIj8Id2rTM+3wcEdUbuAqUMYY=",
       "requires": {
-        "webpack-core": "^0.4.8"
+        "webpack-core": "0.4.8"
       }
     },
     "ci-info": {
@@ -2388,8 +2388,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "clap": {
@@ -2397,7 +2397,7 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       }
     },
     "class-utils": {
@@ -2405,10 +2405,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2416,7 +2416,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -2436,7 +2436,7 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       }
     },
     "cli-boxes": {
@@ -2449,7 +2449,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2462,8 +2462,8 @@
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
       "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
       "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
+        "arch": "2.1.1",
+        "execa": "0.8.0"
       }
     },
     "cliui": {
@@ -2471,9 +2471,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2486,7 +2486,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -2511,7 +2511,7 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -2529,8 +2529,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -2538,9 +2538,9 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.4",
+        "color-convert": "1.9.2",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -2561,7 +2561,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.1"
       }
     },
     "color-support": {
@@ -2574,9 +2574,9 @@
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "colors": {
@@ -2589,7 +2589,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "comma-separated-tokens": {
@@ -2610,7 +2610,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "common-tags": {
@@ -2643,7 +2643,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": ">= 1.34.0 < 2"
+        "mime-db": "1.35.0"
       }
     },
     "compression": {
@@ -2651,13 +2651,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "2.0.14",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       }
     },
     "concat-map": {
@@ -2670,10 +2670,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -2681,12 +2681,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -2699,7 +2699,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -2762,12 +2762,12 @@
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
       "integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
       "requires": {
-        "glob": "^7.0.5",
-        "ltcdr": "^2.2.1",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^0.5.1",
+        "glob": "7.1.2",
+        "ltcdr": "2.2.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "noms": "0.0.0",
-        "through2": "^2.0.1"
+        "through2": "2.0.3"
       }
     },
     "core-js": {
@@ -2785,8 +2785,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-error-class": {
@@ -2794,7 +2794,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -2802,11 +2802,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2814,12 +2814,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -2827,9 +2827,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "cross-env": {
@@ -2837,8 +2837,8 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
       "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
       "requires": {
-        "cross-spawn": "^5.1.0",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "cross-spawn": {
@@ -2846,9 +2846,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypt": {
@@ -2861,7 +2861,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.x.x"
+        "boom": "2.10.1"
       }
     },
     "crypto-browserify": {
@@ -2869,17 +2869,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "crypto-random-string": {
@@ -2893,9 +2893,9 @@
       "integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
       "requires": {
         "balanced-match": "0.1.0",
-        "color": "^0.11.0",
-        "debug": "^3.1.0",
-        "rgb": "~0.1.0"
+        "color": "0.11.4",
+        "debug": "3.1.0",
+        "rgb": "0.1.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -2923,8 +2923,8 @@
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
       "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
       "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
+        "hyphenate-style-name": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -2939,18 +2939,18 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
       "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
       "requires": {
-        "babel-code-frame": "^6.11.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssnano": ">=2.6.1 <4",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.6",
-        "postcss-modules-extract-imports": "^1.0.0",
-        "postcss-modules-local-by-default": "^1.0.1",
-        "postcss-modules-scope": "^1.0.0",
-        "postcss-modules-values": "^1.1.0",
-        "source-list-map": "^0.1.7"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "source-list-map": "0.1.8"
       },
       "dependencies": {
         "loader-utils": {
@@ -2958,9 +2958,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -2970,10 +2970,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-selector-parser": {
@@ -2986,9 +2986,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -2996,9 +2996,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         }
       }
@@ -3018,38 +3018,38 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
-        "autoprefixer": "^6.3.1",
-        "decamelize": "^1.1.2",
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.14",
-        "postcss-calc": "^5.2.0",
-        "postcss-colormin": "^2.1.8",
-        "postcss-convert-values": "^2.3.4",
-        "postcss-discard-comments": "^2.0.4",
-        "postcss-discard-duplicates": "^2.0.1",
-        "postcss-discard-empty": "^2.0.1",
-        "postcss-discard-overridden": "^0.1.1",
-        "postcss-discard-unused": "^2.2.1",
-        "postcss-filter-plugins": "^2.0.0",
-        "postcss-merge-idents": "^2.1.5",
-        "postcss-merge-longhand": "^2.0.1",
-        "postcss-merge-rules": "^2.0.3",
-        "postcss-minify-font-values": "^1.0.2",
-        "postcss-minify-gradients": "^1.0.1",
-        "postcss-minify-params": "^1.0.4",
-        "postcss-minify-selectors": "^2.0.4",
-        "postcss-normalize-charset": "^1.1.0",
-        "postcss-normalize-url": "^3.0.7",
-        "postcss-ordered-values": "^2.1.0",
-        "postcss-reduce-idents": "^2.2.2",
-        "postcss-reduce-initial": "^1.0.0",
-        "postcss-reduce-transforms": "^1.0.3",
-        "postcss-svgo": "^2.1.1",
-        "postcss-unique-selectors": "^2.0.2",
-        "postcss-value-parser": "^3.2.3",
-        "postcss-zindex": "^2.0.1"
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.3",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.3",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
       }
     },
     "csso": {
@@ -3057,8 +3057,8 @@
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
       }
     },
     "csstype": {
@@ -3071,7 +3071,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cwebp-bin": {
@@ -3079,9 +3079,9 @@
       "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-4.0.0.tgz",
       "integrity": "sha1-7it/YzPTQm+1K7QF+m8uyLYolPQ=",
       "requires": {
-        "bin-build": "^2.2.0",
-        "bin-wrapper": "^3.0.1",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "d": {
@@ -3089,7 +3089,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.45"
       }
     },
     "dashdash": {
@@ -3097,7 +3097,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -3144,15 +3144,15 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "requires": {
-        "buffer-to-vinyl": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "decompress-tar": "^3.0.0",
-        "decompress-tarbz2": "^3.0.0",
-        "decompress-targz": "^3.0.0",
-        "decompress-unzip": "^3.0.0",
-        "stream-combiner2": "^1.1.1",
-        "vinyl-assign": "^1.0.1",
-        "vinyl-fs": "^2.2.0"
+        "buffer-to-vinyl": "1.1.0",
+        "concat-stream": "1.6.2",
+        "decompress-tar": "3.1.0",
+        "decompress-tarbz2": "3.1.0",
+        "decompress-targz": "3.1.0",
+        "decompress-unzip": "3.4.0",
+        "stream-combiner2": "1.1.1",
+        "vinyl-assign": "1.2.1",
+        "vinyl-fs": "2.4.4"
       }
     },
     "decompress-response": {
@@ -3160,7 +3160,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "decompress-tar": {
@@ -3168,12 +3168,12 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "requires": {
-        "is-tar": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-tar": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.1",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3196,10 +3196,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3212,8 +3212,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3221,8 +3221,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3232,13 +3232,13 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "requires": {
-        "is-bzip2": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "seek-bzip": "^1.0.3",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-bzip2": "1.0.0",
+        "object-assign": "2.1.1",
+        "seek-bzip": "1.0.5",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.1",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3261,10 +3261,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3277,8 +3277,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3286,8 +3286,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3297,12 +3297,12 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "requires": {
-        "is-gzip": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-gzip": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.1",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -3325,10 +3325,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3341,8 +3341,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -3350,8 +3350,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -3361,13 +3361,13 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "requires": {
-        "is-zip": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "stat-mode": "^0.2.0",
-        "strip-dirs": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0",
-        "yauzl": "^2.2.1"
+        "is-zip": "1.0.0",
+        "read-all-stream": "3.1.0",
+        "stat-mode": "0.2.2",
+        "strip-dirs": "1.1.1",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "yauzl": "2.10.0"
       }
     },
     "deep-equal": {
@@ -3390,8 +3390,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -3399,8 +3399,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3408,7 +3408,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3416,7 +3416,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3424,9 +3424,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -3451,12 +3451,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3479,8 +3479,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -3493,7 +3493,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
       "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
       "requires": {
-        "repeat-string": "^1.5.4"
+        "repeat-string": "1.6.1"
       }
     },
     "detect-file": {
@@ -3507,7 +3507,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-libc": {
@@ -3520,8 +3520,8 @@
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.3.tgz",
       "integrity": "sha512-IDbrX6PxqnYy8jV4wSHBaJlErYKTJvW8OQb9F7xivl1iQLqiUYHGa+nZ61Do6+N5uuOn/pReXKNqI9rUn04vug==",
       "requires": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
+        "address": "1.0.3",
+        "debug": "2.6.9"
       }
     },
     "devcert-san": {
@@ -3529,22 +3529,22 @@
       "resolved": "https://registry.npmjs.org/devcert-san/-/devcert-san-0.3.3.tgz",
       "integrity": "sha1-qnckR0Gy2DF3HAEfIu4l45atS6k=",
       "requires": {
-        "@types/configstore": "^2.1.1",
-        "@types/debug": "^0.0.29",
-        "@types/get-port": "^0.0.4",
-        "@types/glob": "^5.0.30",
-        "@types/mkdirp": "^0.3.29",
-        "@types/node": "^7.0.11",
-        "@types/tmp": "^0.0.32",
-        "command-exists": "^1.2.2",
-        "configstore": "^3.0.0",
-        "debug": "^2.6.3",
-        "eol": "^0.8.1",
-        "get-port": "^3.0.0",
-        "glob": "^7.1.1",
-        "mkdirp": "^0.5.1",
-        "tmp": "^0.0.31",
-        "tslib": "^1.6.0"
+        "@types/configstore": "2.1.1",
+        "@types/debug": "0.0.29",
+        "@types/get-port": "0.0.4",
+        "@types/glob": "5.0.35",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "7.0.68",
+        "@types/tmp": "0.0.32",
+        "command-exists": "1.2.7",
+        "configstore": "3.1.2",
+        "debug": "2.6.9",
+        "eol": "0.8.1",
+        "get-port": "3.2.0",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "tmp": "0.0.31",
+        "tslib": "1.9.3"
       }
     },
     "diacritics": {
@@ -3557,9 +3557,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "direction": {
@@ -3577,10 +3577,10 @@
       "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.6.0.tgz",
       "integrity": "sha1-ErrWbVh0LG5ffPKUP7aFlED4CcQ=",
       "requires": {
-        "asap": "^2.0.6",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "redux": "^3.7.1"
+        "asap": "2.0.6",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10",
+        "redux": "3.7.2"
       }
     },
     "dom-converter": {
@@ -3588,7 +3588,7 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "requires": {
-        "utila": "~0.3"
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -3608,8 +3608,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3639,7 +3639,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domready": {
@@ -3652,8 +3652,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3661,7 +3661,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotenv": {
@@ -3674,21 +3674,21 @@
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "requires": {
-        "caw": "^1.0.1",
-        "concat-stream": "^1.4.7",
-        "each-async": "^1.0.0",
-        "filenamify": "^1.0.1",
-        "got": "^5.0.0",
-        "gulp-decompress": "^1.2.0",
-        "gulp-rename": "^1.2.0",
-        "is-url": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.2",
-        "stream-combiner2": "^1.1.1",
-        "vinyl": "^1.0.0",
-        "vinyl-fs": "^2.2.0",
-        "ware": "^1.2.0"
+        "caw": "1.2.0",
+        "concat-stream": "1.6.2",
+        "each-async": "1.1.1",
+        "filenamify": "1.2.1",
+        "got": "5.7.1",
+        "gulp-decompress": "1.2.0",
+        "gulp-rename": "1.4.0",
+        "is-url": "1.2.4",
+        "object-assign": "4.1.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.6",
+        "stream-combiner2": "1.1.1",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "got": {
@@ -3696,21 +3696,21 @@
           "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
           "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
           "requires": {
-            "create-error-class": "^3.0.1",
-            "duplexer2": "^0.1.4",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "node-status-codes": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "parse-json": "^2.1.0",
-            "pinkie-promise": "^2.0.0",
-            "read-all-stream": "^3.0.0",
-            "readable-stream": "^2.0.5",
-            "timed-out": "^3.0.0",
-            "unzip-response": "^1.0.2",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.6",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
           }
         },
         "timed-out": {
@@ -3735,7 +3735,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexer3": {
@@ -3748,10 +3748,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "each-async": {
@@ -3759,8 +3759,8 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "^1.0.0",
-        "set-immediate-shim": "^1.0.0"
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "onetime": {
@@ -3776,8 +3776,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -3795,13 +3795,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.5",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -3824,7 +3824,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
     "end-of-stream": {
@@ -3832,7 +3832,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -3840,12 +3840,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -3861,9 +3861,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -3875,14 +3875,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3899,9 +3899,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -3912,10 +3912,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "enhanced-resolve": {
@@ -3923,9 +3923,9 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.2.0",
-        "tapable": "^0.1.8"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.2.0",
+        "tapable": "0.1.10"
       },
       "dependencies": {
         "memory-fs": {
@@ -3961,7 +3961,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -3969,7 +3969,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -3977,7 +3977,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
       "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
       "requires": {
-        "stackframe": "^1.0.4"
+        "stackframe": "1.0.4"
       }
     },
     "es5-ext": {
@@ -3985,9 +3985,9 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
       "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -3995,9 +3995,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-promise": {
@@ -4010,8 +4010,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45"
       }
     },
     "es6-template-strings": {
@@ -4020,8 +4020,8 @@
       "integrity": "sha1-sWbGpiVi9Hi7d3X2ypYQOlmbSyw=",
       "optional": true,
       "requires": {
-        "es5-ext": "^0.10.12",
-        "esniff": "^1.1"
+        "es5-ext": "0.10.45",
+        "esniff": "1.1.0"
       }
     },
     "escape-html": {
@@ -4040,8 +4040,8 @@
       "integrity": "sha1-xmhJIp+RRk3t4uDUAgHtar9l8qw=",
       "optional": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.12"
+        "d": "1.0.0",
+        "es5-ext": "0.10.45"
       }
     },
     "esprima": {
@@ -4069,7 +4069,7 @@
       "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.2.tgz",
       "integrity": "sha1-n3EDKEwQWmbfQDCysycxZYNwE9o=",
       "requires": {
-        "require-like": ">= 0.1.1"
+        "require-like": "0.1.2"
       }
     },
     "eventemitter3": {
@@ -4087,7 +4087,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.1"
       }
     },
     "evp_bytestokey": {
@@ -4095,8 +4095,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-buffer": {
@@ -4104,11 +4104,11 @@
       "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
       "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "requires": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
+        "execa": "0.7.0",
+        "p-finally": "1.0.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2",
+        "tempfile": "2.0.0"
       },
       "dependencies": {
         "execa": {
@@ -4116,13 +4116,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -4132,8 +4132,8 @@
       "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
       "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
       "requires": {
-        "async-each-series": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "async-each-series": "1.1.0",
+        "object-assign": "4.1.1"
       }
     },
     "exec-sh": {
@@ -4142,7 +4142,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "optional": true,
       "requires": {
-        "merge": "^1.2.0"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -4150,13 +4150,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "executable": {
@@ -4164,7 +4164,7 @@
       "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
       "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
       "requires": {
-        "meow": "^3.1.0"
+        "meow": "3.7.0"
       }
     },
     "exenv": {
@@ -4182,7 +4182,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -4190,7 +4190,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-template": {
@@ -4203,7 +4203,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "os-homedir": "^1.0.1"
+        "os-homedir": "1.0.2"
       }
     },
     "express": {
@@ -4211,36 +4211,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -4255,10 +4255,10 @@
       "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.6.12.tgz",
       "integrity": "sha512-ouLWV0hRw4hnaLtXzzwhdC79ewxKbY2PRvm05mPc/zOH5W5WVCHDQ1SmNxEPBQdUeeSNh29aIqW9zEQkA3kMuA==",
       "requires": {
-        "accepts": "^1.3.0",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.3.0",
-        "raw-body": "^2.3.2"
+        "accepts": "1.3.5",
+        "content-type": "1.0.4",
+        "http-errors": "1.6.3",
+        "raw-body": "2.3.2"
       }
     },
     "extend": {
@@ -4271,8 +4271,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4280,7 +4280,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4290,9 +4290,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "tmp": {
@@ -4300,7 +4300,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -4310,7 +4310,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -4318,9 +4318,9 @@
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
       "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
       "requires": {
-        "async": "^1.5.0",
-        "loader-utils": "^0.2.3",
-        "webpack-sources": "^0.1.0"
+        "async": "1.5.2",
+        "loader-utils": "0.2.17",
+        "webpack-sources": "0.1.5"
       },
       "dependencies": {
         "async": {
@@ -4340,9 +4340,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       },
       "dependencies": {
         "time-stamp": {
@@ -4362,10 +4362,10 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-1.0.1.tgz",
       "integrity": "sha512-C2VHbdBwSkaQDyavjQZDflZzmZKrsUK3fTdJtsOnED0L0vtHCw+NL0h8pRcydbpRHlNJLZ4/LbOfEdJKspK91A==",
       "requires": {
-        "bash-glob": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "micromatch": "^3.0.3",
-        "readdir-enhanced": "^1.5.2"
+        "bash-glob": "1.0.2",
+        "glob-parent": "3.1.0",
+        "micromatch": "3.1.10",
+        "readdir-enhanced": "1.5.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -4383,16 +4383,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4400,7 +4400,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4410,13 +4410,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4424,7 +4424,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4432,7 +4432,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -4440,7 +4440,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4448,7 +4448,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4458,7 +4458,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4466,7 +4466,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4476,9 +4476,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4493,14 +4493,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4508,7 +4508,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4516,7 +4516,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4526,10 +4526,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4537,7 +4537,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4547,8 +4547,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -4556,7 +4556,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4564,7 +4564,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4572,9 +4572,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -4587,7 +4587,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4595,7 +4595,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4603,7 +4603,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4623,19 +4623,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4655,7 +4655,7 @@
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
       "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
       "requires": {
-        "punycode": "^1.3.2"
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -4675,7 +4675,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -4683,7 +4683,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbjs": {
@@ -4691,13 +4691,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -4712,7 +4712,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -4720,7 +4720,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-loader": {
@@ -4728,7 +4728,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
       "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
       "requires": {
-        "loader-utils": "~0.2.5"
+        "loader-utils": "0.2.17"
       }
     },
     "file-type": {
@@ -4751,9 +4751,9 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
       }
     },
     "filesize": {
@@ -4766,11 +4766,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -4779,12 +4779,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "find-cache-dir": {
@@ -4792,9 +4792,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "requires": {
-        "commondir": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pkg-dir": "^1.0.0"
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
       }
     },
     "find-node-modules": {
@@ -4803,7 +4803,7 @@
       "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
       "requires": {
         "findup-sync": "0.4.2",
-        "merge": "^1.2.0"
+        "merge": "1.2.0"
       },
       "dependencies": {
         "detect-file": {
@@ -4811,7 +4811,7 @@
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
           "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
           "requires": {
-            "fs-exists-sync": "^0.1.0"
+            "fs-exists-sync": "0.1.0"
           }
         },
         "findup-sync": {
@@ -4819,10 +4819,10 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
           "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
           "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
+            "detect-file": "0.1.0",
+            "is-glob": "2.0.1",
+            "micromatch": "2.3.11",
+            "resolve-dir": "0.1.1"
           }
         },
         "global-modules": {
@@ -4830,8 +4830,8 @@
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
           }
         },
         "global-prefix": {
@@ -4839,10 +4839,10 @@
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.1"
           }
         },
         "is-windows": {
@@ -4855,8 +4855,8 @@
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
           }
         }
       }
@@ -4866,8 +4866,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "path-exists": {
@@ -4875,7 +4875,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -4885,10 +4885,10 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
       "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
       "requires": {
-        "array-uniq": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "meow": "^3.5.0",
-        "semver-regex": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
       }
     },
     "findup-sync": {
@@ -4897,10 +4897,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "optional": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4920,16 +4920,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "optional": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4938,7 +4938,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4949,13 +4949,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "optional": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4964,7 +4964,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "optional": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4973,7 +4973,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -4982,7 +4982,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "optional": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4991,7 +4991,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "optional": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5002,7 +5002,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "optional": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5011,7 +5011,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "optional": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5022,9 +5022,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "optional": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -5041,14 +5041,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "optional": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5057,7 +5057,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "optional": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -5066,7 +5066,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5077,10 +5077,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "optional": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5089,7 +5089,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "optional": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5100,7 +5100,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5109,7 +5109,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "optional": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5118,9 +5118,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "optional": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -5135,7 +5135,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "optional": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -5144,7 +5144,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "optional": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5153,7 +5153,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "optional": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5175,19 +5175,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "optional": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -5198,11 +5198,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "optional": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       },
       "dependencies": {
         "expand-tilde": {
@@ -5211,7 +5211,7 @@
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "optional": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -5232,7 +5232,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
       "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
       "requires": {
-        "is-buffer": "~1.1.2"
+        "is-buffer": "1.1.6"
       }
     },
     "flatten": {
@@ -5250,7 +5250,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
       "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5268,7 +5268,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.4"
       }
     },
     "for-in": {
@@ -5281,7 +5281,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -5299,9 +5299,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.19"
       }
     },
     "forwarded": {
@@ -5314,7 +5314,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -5327,9 +5327,9 @@
       "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz",
       "integrity": "sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==",
       "requires": {
-        "chalk": "^1.1.3",
-        "error-stack-parser": "^2.0.0",
-        "string-width": "^2.0.0"
+        "chalk": "1.1.3",
+        "error-stack-parser": "2.0.2",
+        "string-width": "2.1.1"
       }
     },
     "front-matter": {
@@ -5337,7 +5337,7 @@
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
       "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
       "requires": {
-        "js-yaml": "^3.10.0"
+        "js-yaml": "3.12.0"
       },
       "dependencies": {
         "esprima": {
@@ -5350,8 +5350,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         }
       }
@@ -5376,9 +5376,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs-minipass": {
@@ -5386,7 +5386,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "fs-readdir-recursive": {
@@ -5405,8 +5405,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5428,8 +5428,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -5440,7 +5440,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5494,7 +5494,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -5507,14 +5507,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -5522,12 +5522,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5540,7 +5540,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5548,7 +5548,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5556,8 +5556,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -5573,7 +5573,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5585,7 +5585,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -5596,8 +5596,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -5605,7 +5605,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -5625,9 +5625,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5635,16 +5635,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -5652,8 +5652,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5666,8 +5666,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -5675,10 +5675,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5694,7 +5694,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5712,8 +5712,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5731,10 +5731,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5749,13 +5749,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5763,7 +5763,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -5799,9 +5799,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5809,14 +5809,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5829,13 +5829,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -5848,7 +5848,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5866,10 +5866,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "function-bind": {
@@ -5887,116 +5887,116 @@
       "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-1.9.277.tgz",
       "integrity": "sha1-0vWmIG/GbtRvz1eYXUseK0kelVk=",
       "requires": {
-        "async": "^2.1.2",
-        "babel-code-frame": "^6.22.0",
-        "babel-core": "^6.24.1",
-        "babel-loader": "^6.0.0",
-        "babel-plugin-add-module-exports": "^0.2.1",
-        "babel-plugin-transform-object-assign": "^6.8.0",
-        "babel-polyfill": "^6.23.0",
-        "babel-preset-env": "^1.6.0",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-react": "^6.24.1",
-        "babel-preset-stage-0": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.24.1",
-        "babylon": "^6.17.3",
-        "better-queue": "^3.8.6",
-        "bluebird": "^3.5.0",
-        "chalk": "^1.1.3",
-        "chokidar": "^1.7.0",
+        "async": "2.6.1",
+        "babel-code-frame": "6.26.0",
+        "babel-core": "6.26.3",
+        "babel-loader": "6.4.1",
+        "babel-plugin-add-module-exports": "0.2.1",
+        "babel-plugin-transform-object-assign": "6.22.0",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-env": "1.7.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-react": "6.24.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "better-queue": "3.8.10",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
         "chunk-manifest-webpack-plugin": "0.1.0",
-        "common-tags": "^1.4.0",
-        "convert-hrtime": "^2.0.0",
-        "copyfiles": "^1.2.0",
-        "core-js": "^2.5.0",
-        "css-loader": "^0.26.1",
-        "debug": "^2.6.0",
-        "del": "^3.0.0",
-        "detect-port": "^1.2.1",
-        "devcert-san": "^0.3.3",
-        "domready": "^1.0.8",
-        "dotenv": "^4.0.0",
-        "express": "^4.14.0",
-        "express-graphql": "^0.6.6",
-        "fast-levenshtein": "~2.0.4",
-        "file-loader": "^0.9.0",
-        "flat": "^2.0.1",
-        "friendly-errors-webpack-plugin": "^1.6.1",
-        "front-matter": "^2.1.0",
-        "fs-extra": "^4.0.1",
-        "gatsby-1-config-css-modules": "^1.0.11",
-        "gatsby-1-config-extract-plugin": "^1.0.3",
-        "gatsby-cli": "^1.1.58",
-        "gatsby-link": "^1.6.46",
-        "gatsby-module-loader": "^1.0.11",
-        "gatsby-plugin-page-creator": "^1.0.1",
-        "gatsby-react-router-scroll": "^1.0.18",
-        "glob": "^7.1.1",
-        "graphql": "^0.11.7",
-        "graphql-relay": "^0.5.1",
-        "graphql-skip-limit": "^1.0.11",
-        "history": "^4.6.2",
-        "invariant": "^2.2.2",
-        "is-relative": "^0.2.1",
-        "is-relative-url": "^2.0.0",
-        "joi": "12.x.x",
-        "json-loader": "^0.5.2",
-        "json-stringify-safe": "^5.0.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.4",
-        "lodash-id": "^0.14.0",
-        "lowdb": "^0.16.2",
-        "md5": "^2.2.1",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "mitt": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.16.0",
-        "node-libs-browser": "^2.0.0",
-        "normalize-path": "^2.1.1",
-        "null-loader": "^0.1.1",
-        "opn": "^5.1.0",
-        "parse-filepath": "^1.0.1",
-        "path-exists": "^3.0.0",
-        "postcss-browser-reporter": "^0.5.0",
-        "postcss-cssnext": "^2.8.0",
-        "postcss-import": "^8.2.0",
-        "postcss-loader": "^0.13.0",
-        "postcss-reporter": "^1.4.1",
-        "raw-loader": "^0.5.1",
-        "react": "^15.6.0",
-        "react-dev-utils": "^4.2.1",
-        "react-dom": "^15.6.0",
-        "react-error-overlay": "^3.0.0",
-        "react-hot-loader": "^3.0.0-beta.6",
-        "react-router": "^4.1.1",
-        "react-router-dom": "^4.1.1",
-        "redux": "^3.6.0",
+        "common-tags": "1.8.0",
+        "convert-hrtime": "2.0.0",
+        "copyfiles": "1.2.0",
+        "core-js": "2.5.7",
+        "css-loader": "0.26.4",
+        "debug": "2.6.9",
+        "del": "3.0.0",
+        "detect-port": "1.2.3",
+        "devcert-san": "0.3.3",
+        "domready": "1.0.8",
+        "dotenv": "4.0.0",
+        "express": "4.16.3",
+        "express-graphql": "0.6.12",
+        "fast-levenshtein": "2.0.6",
+        "file-loader": "0.9.0",
+        "flat": "2.0.1",
+        "friendly-errors-webpack-plugin": "1.7.0",
+        "front-matter": "2.3.0",
+        "fs-extra": "4.0.3",
+        "gatsby-1-config-css-modules": "1.0.11",
+        "gatsby-1-config-extract-plugin": "1.0.3",
+        "gatsby-cli": "1.1.58",
+        "gatsby-link": "1.6.46",
+        "gatsby-module-loader": "1.0.11",
+        "gatsby-plugin-page-creator": "1.0.1",
+        "gatsby-react-router-scroll": "1.0.18",
+        "glob": "7.1.2",
+        "graphql": "0.11.7",
+        "graphql-relay": "0.5.5",
+        "graphql-skip-limit": "1.0.11",
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "is-relative": "0.2.1",
+        "is-relative-url": "2.0.0",
+        "joi": "12.0.0",
+        "json-loader": "0.5.7",
+        "json-stringify-safe": "5.0.1",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "lodash-id": "0.14.0",
+        "lowdb": "0.16.2",
+        "md5": "2.2.1",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "mitt": "1.1.3",
+        "mkdirp": "0.5.1",
+        "moment": "2.22.2",
+        "node-libs-browser": "2.1.0",
+        "normalize-path": "2.1.1",
+        "null-loader": "0.1.1",
+        "opn": "5.3.0",
+        "parse-filepath": "1.0.2",
+        "path-exists": "3.0.0",
+        "postcss-browser-reporter": "0.5.0",
+        "postcss-cssnext": "2.11.0",
+        "postcss-import": "8.2.0",
+        "postcss-loader": "0.13.0",
+        "postcss-reporter": "1.4.1",
+        "raw-loader": "0.5.1",
+        "react": "15.6.2",
+        "react-dev-utils": "4.2.1",
+        "react-dom": "15.6.2",
+        "react-error-overlay": "3.0.0",
+        "react-hot-loader": "3.1.3",
+        "react-router": "4.3.1",
+        "react-router-dom": "4.3.1",
+        "redux": "3.7.2",
         "relay-compiler": "1.4.1",
-        "remote-redux-devtools": "^0.5.7",
-        "serve": "^9.2.0",
-        "shallow-compare": "^1.2.2",
-        "sift": "^3.2.6",
-        "signal-exit": "^3.0.2",
-        "slash": "^1.0.0",
-        "socket.io": "^2.0.3",
-        "static-site-generator-webpack-plugin": "^3.4.1",
-        "string-similarity": "^1.2.0",
-        "style-loader": "^0.13.0",
-        "type-of": "^2.0.1",
-        "url-loader": "^0.6.2",
-        "uuid": "^3.1.0",
-        "v8-compile-cache": "^1.1.0",
-        "webpack": "^1.13.3",
-        "webpack-configurator": "^0.3.0",
-        "webpack-dev-middleware": "^1.8.4",
-        "webpack-dev-server": "^1.16.1",
-        "webpack-hot-middleware": "^2.13.2",
+        "remote-redux-devtools": "0.5.12",
+        "serve": "9.4.0",
+        "shallow-compare": "1.2.2",
+        "sift": "3.3.12",
+        "signal-exit": "3.0.2",
+        "slash": "1.0.0",
+        "socket.io": "2.1.1",
+        "static-site-generator-webpack-plugin": "3.4.1",
+        "string-similarity": "1.2.0",
+        "style-loader": "0.13.2",
+        "type-of": "2.0.1",
+        "url-loader": "0.6.2",
+        "uuid": "3.3.2",
+        "v8-compile-cache": "1.1.2",
+        "webpack": "1.15.0",
+        "webpack-configurator": "0.3.1",
+        "webpack-dev-middleware": "1.12.2",
+        "webpack-dev-server": "1.16.5",
+        "webpack-hot-middleware": "2.22.3",
         "webpack-md5-hash": "0.0.5",
-        "webpack-stats-plugin": "^0.1.4",
-        "webpack-validator": "^2.2.7",
-        "yaml-loader": "^0.4.0"
+        "webpack-stats-plugin": "0.1.5",
+        "webpack-validator": "2.3.0",
+        "yaml-loader": "0.4.0"
       },
       "dependencies": {
         "gatsby-cli": {
@@ -6004,24 +6004,24 @@
           "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-1.1.58.tgz",
           "integrity": "sha1-Xdoka5h3q5JfalEvcjwgVXryLVc=",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "bluebird": "^3.5.0",
-            "common-tags": "^1.4.0",
-            "convert-hrtime": "^2.0.0",
-            "core-js": "^2.5.0",
-            "envinfo": "^5.8.1",
-            "execa": "^0.8.0",
-            "fs-extra": "^4.0.1",
-            "hosted-git-info": "^2.5.0",
-            "lodash": "^4.17.4",
-            "pretty-error": "^2.1.1",
-            "resolve-cwd": "^2.0.0",
-            "source-map": "^0.5.7",
-            "stack-trace": "^0.0.10",
-            "update-notifier": "^2.3.0",
-            "yargs": "^11.1.0",
-            "yurnalist": "^0.2.1"
+            "babel-code-frame": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "bluebird": "3.5.1",
+            "common-tags": "1.8.0",
+            "convert-hrtime": "2.0.0",
+            "core-js": "2.5.7",
+            "envinfo": "5.10.0",
+            "execa": "0.8.0",
+            "fs-extra": "4.0.3",
+            "hosted-git-info": "2.7.1",
+            "lodash": "4.17.10",
+            "pretty-error": "2.1.1",
+            "resolve-cwd": "2.0.0",
+            "source-map": "0.5.7",
+            "stack-trace": "0.0.10",
+            "update-notifier": "2.5.0",
+            "yargs": "11.1.0",
+            "yurnalist": "0.2.1"
           }
         },
         "react": {
@@ -6029,11 +6029,11 @@
           "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
           "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
           "requires": {
-            "create-react-class": "^15.6.0",
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.0",
-            "prop-types": "^15.5.10"
+            "create-react-class": "15.6.3",
+            "fbjs": "0.8.17",
+            "loose-envify": "1.4.0",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.2"
           }
         }
       }
@@ -6043,7 +6043,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-css-modules/-/gatsby-1-config-css-modules-1.0.11.tgz",
       "integrity": "sha1-WhAsaxH5ppY7OJLsyVlRHhaI5SU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-1-config-extract-plugin": {
@@ -6051,8 +6051,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-extract-plugin/-/gatsby-1-config-extract-plugin-1.0.3.tgz",
       "integrity": "sha1-niyWLUVjyV+inag+PZMBcSmvARU=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "extract-text-webpack-plugin": "^1.0.1"
+        "babel-runtime": "6.26.0",
+        "extract-text-webpack-plugin": "1.0.1"
       }
     },
     "gatsby-link": {
@@ -6060,11 +6060,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-1.6.46.tgz",
       "integrity": "sha1-H59r16TUSKhWwgNeVPImPXkz9P0=",
       "requires": {
-        "@types/history": "^4.6.2",
-        "@types/react-router-dom": "^4.2.2",
-        "babel-runtime": "^6.26.0",
-        "prop-types": "^15.5.8",
-        "ric": "^1.3.0"
+        "@types/history": "4.7.0",
+        "@types/react-router-dom": "4.3.0",
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.2",
+        "ric": "1.3.0"
       }
     },
     "gatsby-module-loader": {
@@ -6072,8 +6072,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-module-loader/-/gatsby-module-loader-1.0.11.tgz",
       "integrity": "sha1-NfJpRW9qbYXGk73Cs7OzQymH9Vs=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "loader-utils": "^0.2.16"
+        "babel-runtime": "6.26.0",
+        "loader-utils": "0.2.17"
       }
     },
     "gatsby-plugin-netlify": {
@@ -6081,10 +6081,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify/-/gatsby-plugin-netlify-1.0.21.tgz",
       "integrity": "sha1-pM1mMeLHPXMXfxzoUy8SVgHIxCY=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "fs-extra": "^4.0.2",
-        "lodash": "^4.17.4",
-        "webpack-assets-manifest": "^1.0.0"
+        "babel-runtime": "6.26.0",
+        "fs-extra": "4.0.3",
+        "lodash": "4.17.10",
+        "webpack-assets-manifest": "1.0.0"
       }
     },
     "gatsby-plugin-netlify-cms": {
@@ -6092,10 +6092,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-1.0.12.tgz",
       "integrity": "sha1-lhFE9Fz3aqo1G2OXd2NfcKUgAec=",
       "requires": {
-        "html-webpack-include-assets-plugin": "^1.0.2",
-        "html-webpack-plugin": "^2.30.1",
-        "netlify-cms": "^1.0.1",
-        "netlify-identity-widget": "^1.4.11"
+        "html-webpack-include-assets-plugin": "1.0.4",
+        "html-webpack-plugin": "2.30.1",
+        "netlify-cms": "1.9.3",
+        "netlify-identity-widget": "1.4.14"
       }
     },
     "gatsby-plugin-page-creator": {
@@ -6103,13 +6103,13 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-1.0.1.tgz",
       "integrity": "sha1-a60zp/Rstbh9varMPBu9gaxjvCA=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "chokidar": "^1.7.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.4",
-        "parse-filepath": "^1.0.1",
-        "slash": "^1.0.0"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "chokidar": "1.7.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "parse-filepath": "1.0.2",
+        "slash": "1.0.0"
       }
     },
     "gatsby-plugin-react-helmet": {
@@ -6117,7 +6117,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-2.0.11.tgz",
       "integrity": "sha1-otuBdV9bQdVODlNcodmgCNPM/wo=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-plugin-sass": {
@@ -6125,12 +6125,20 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-1.0.26.tgz",
       "integrity": "sha1-PQkzTfULfz9YjNtcAAk+OWmB8bU=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "gatsby-1-config-css-modules": "^1.0.11",
-        "gatsby-1-config-extract-plugin": "^1.0.3",
-        "node-sass": "^4.5.2",
-        "sass-loader": "^4.1.1",
-        "webpack": "^1.13.3"
+        "babel-runtime": "6.26.0",
+        "gatsby-1-config-css-modules": "1.0.11",
+        "gatsby-1-config-extract-plugin": "1.0.3",
+        "node-sass": "4.9.2",
+        "sass-loader": "4.1.1",
+        "webpack": "1.15.0"
+      }
+    },
+    "gatsby-plugin-segment-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-segment-js/-/gatsby-plugin-segment-js-2.0.1.tgz",
+      "integrity": "sha512-2cCljmt7kbC/8V1LasmxfusCljjl64/pqKwwQRKh5WSe1+zr844cz6mKa656tLtv+FdEc6rtsZo/7IkPOQIAaQ==",
+      "requires": {
+        "npm": "5.10.0"
       }
     },
     "gatsby-plugin-sharp": {
@@ -6138,19 +6146,19 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.48.tgz",
       "integrity": "sha1-m7dRXanHdTswZcUbLTWg3luaofU=",
       "requires": {
-        "async": "^2.1.2",
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "imagemin": "^5.2.2",
+        "async": "2.6.1",
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "imagemin": "5.3.1",
         "imagemin-pngquant": "5.0.1",
-        "imagemin-webp": "^4.0.0",
-        "lodash": "^4.17.4",
-        "mini-svg-data-uri": "^1.0.0",
-        "potrace": "^2.1.1",
-        "probe-image-size": "^4.0.0",
-        "progress": "^1.1.8",
-        "sharp": "^0.20.0",
-        "svgo": "^0.7.2"
+        "imagemin-webp": "4.1.0",
+        "lodash": "4.17.10",
+        "mini-svg-data-uri": "1.0.1",
+        "potrace": "2.1.1",
+        "probe-image-size": "4.0.0",
+        "progress": "1.1.8",
+        "sharp": "0.20.5",
+        "svgo": "0.7.2"
       }
     },
     "gatsby-react-router-scroll": {
@@ -6158,9 +6166,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.18.tgz",
       "integrity": "sha1-YW/7gB29vkWYYR4v84Ybkaw+7L8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "scroll-behavior": "^0.9.9",
-        "warning": "^3.0.0"
+        "babel-runtime": "6.26.0",
+        "scroll-behavior": "0.9.9",
+        "warning": "3.0.0"
       }
     },
     "gatsby-remark-images": {
@@ -6168,13 +6176,13 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-1.5.67.tgz",
       "integrity": "sha1-aw22hz6hoUHSs8ohGgWrhcVZIuI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "cheerio": "^1.0.0-rc.2",
-        "gatsby-plugin-sharp": "^1.6.48",
-        "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.4",
-        "slash": "^1.0.0",
-        "unist-util-select": "^1.5.0"
+        "babel-runtime": "6.26.0",
+        "cheerio": "1.0.0-rc.2",
+        "gatsby-plugin-sharp": "1.6.48",
+        "is-relative-url": "2.0.0",
+        "lodash": "4.17.10",
+        "slash": "1.0.0",
+        "unist-util-select": "1.5.0"
       },
       "dependencies": {
         "cheerio": {
@@ -6182,12 +6190,12 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
           "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
           "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.9.2",
+            "lodash": "4.17.10",
+            "parse5": "3.0.3"
           }
         },
         "domhandler": {
@@ -6195,7 +6203,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -6203,12 +6211,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "parse5": {
@@ -6216,7 +6224,7 @@
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "requires": {
-            "@types/node": "*"
+            "@types/node": "7.0.68"
           }
         }
       }
@@ -6226,18 +6234,18 @@
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-1.5.39.tgz",
       "integrity": "sha1-x+SbeAljK1PIJ+Zv8+4Lp072Ldg=",
       "requires": {
-        "babel-cli": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "better-queue": "^3.8.7",
-        "bluebird": "^3.5.0",
-        "chokidar": "^1.7.0",
-        "fs-extra": "^4.0.1",
-        "got": "^7.1.0",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "pretty-bytes": "^4.0.2",
-        "slash": "^1.0.0",
-        "valid-url": "^1.0.9"
+        "babel-cli": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "better-queue": "3.8.10",
+        "bluebird": "3.5.1",
+        "chokidar": "1.7.0",
+        "fs-extra": "4.0.3",
+        "got": "7.1.0",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "pretty-bytes": "4.0.2",
+        "slash": "1.0.0",
+        "valid-url": "1.0.9"
       },
       "dependencies": {
         "got": {
@@ -6245,20 +6253,20 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         }
       }
@@ -6268,26 +6276,26 @@
       "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-1.7.44.tgz",
       "integrity": "sha1-abRfN3poSE0eqxPx/reSRCg3jOE=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "graphql-type-json": "^0.1.4",
-        "gray-matter": "^3.0.0",
-        "hast-util-raw": "^2.0.2",
-        "hast-util-to-html": "^3.0.0",
-        "lodash": "^4.17.4",
-        "mdast-util-to-hast": "^2.4.0",
-        "mdast-util-toc": "^2.0.1",
-        "remark": "^7.0.1",
-        "remark-parse": "^4.0.0",
-        "remark-retext": "^3.1.0",
-        "remark-stringify": "^4.0.0",
-        "retext-english": "^3.0.0",
-        "sanitize-html": "^1.14.1",
-        "underscore.string": "^3.3.4",
-        "unified": "^6.1.5",
-        "unist-util-remove-position": "^1.1.1",
-        "unist-util-select": "^1.5.0",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "graphql-type-json": "0.1.4",
+        "gray-matter": "3.1.1",
+        "hast-util-raw": "2.0.2",
+        "hast-util-to-html": "3.1.0",
+        "lodash": "4.17.10",
+        "mdast-util-to-hast": "2.5.0",
+        "mdast-util-toc": "2.0.1",
+        "remark": "7.0.1",
+        "remark-parse": "4.0.0",
+        "remark-retext": "3.1.0",
+        "remark-stringify": "4.0.0",
+        "retext-english": "3.0.0",
+        "sanitize-html": "1.18.4",
+        "underscore.string": "3.3.4",
+        "unified": "6.2.0",
+        "unist-util-remove-position": "1.1.2",
+        "unist-util-select": "1.5.0",
+        "unist-util-visit": "1.4.0"
       },
       "dependencies": {
         "remark-parse": {
@@ -6295,21 +6303,21 @@
           "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
           "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
           "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
+            "collapse-white-space": "1.0.4",
+            "is-alphabetical": "1.0.2",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "is-word-character": "1.0.2",
+            "markdown-escapes": "1.0.2",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
             "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
+            "trim-trailing-lines": "1.1.1",
+            "unherit": "1.1.1",
+            "unist-util-remove-position": "1.1.2",
+            "vfile-location": "2.0.3",
+            "xtend": "4.0.1"
           }
         },
         "remark-stringify": {
@@ -6317,20 +6325,20 @@
           "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
           "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
           "requires": {
-            "ccount": "^1.0.0",
-            "is-alphanumeric": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "longest-streak": "^2.0.1",
-            "markdown-escapes": "^1.0.0",
-            "markdown-table": "^1.1.0",
-            "mdast-util-compact": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "stringify-entities": "^1.0.1",
-            "unherit": "^1.0.4",
-            "xtend": "^4.0.1"
+            "ccount": "1.0.3",
+            "is-alphanumeric": "1.0.0",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "longest-streak": "2.0.2",
+            "markdown-escapes": "1.0.2",
+            "markdown-table": "1.1.2",
+            "mdast-util-compact": "1.0.1",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
+            "stringify-entities": "1.3.2",
+            "unherit": "1.1.1",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -6340,10 +6348,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-1.6.27.tgz",
       "integrity": "sha1-iRZ+TZ/NPPdyvAKTgK+c3NiOI6E=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "fs-extra": "^4.0.2",
-        "probe-image-size": "^4.0.0"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "fs-extra": "4.0.3",
+        "probe-image-size": "4.0.0"
       }
     },
     "gauge": {
@@ -6351,11 +6359,11 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
+        "ansi": "0.3.1",
+        "has-unicode": "2.0.1",
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
       }
     },
     "gaze": {
@@ -6363,7 +6371,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "requires": {
-        "globule": "^1.0.0"
+        "globule": "1.2.1"
       }
     },
     "get-caller-file": {
@@ -6391,7 +6399,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "requires": {
-        "rc": "^1.1.2"
+        "rc": "1.2.8"
       }
     },
     "get-stdin": {
@@ -6414,7 +6422,7 @@
       "resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
       "integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
       "requires": {
-        "get-document": "1"
+        "get-document": "1.0.0"
       }
     },
     "getpass": {
@@ -6422,7 +6430,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "github-from-package": {
@@ -6435,7 +6443,7 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
       "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
       "requires": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
+        "emoji-regex": "6.1.1"
       }
     },
     "glob": {
@@ -6443,12 +6451,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -6456,8 +6464,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -6465,7 +6473,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-slash": {
@@ -6478,9 +6486,9 @@
       "resolved": "https://registry.npmjs.org/glob-slasher/-/glob-slasher-1.0.1.tgz",
       "integrity": "sha1-dHoOW7IiZC7hDT4FRD4QlJPLD44=",
       "requires": {
-        "glob-slash": "^1.0.0",
-        "lodash.isobject": "^2.4.1",
-        "toxic": "^1.0.0"
+        "glob-slash": "1.0.0",
+        "lodash.isobject": "2.4.1",
+        "toxic": "1.0.1"
       }
     },
     "glob-stream": {
@@ -6488,14 +6496,14 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.2",
+        "glob": "5.0.15",
+        "glob-parent": "3.1.0",
+        "micromatch": "2.3.11",
+        "ordered-read-streams": "0.3.0",
+        "through2": "0.6.5",
+        "to-absolute-glob": "0.1.1",
+        "unique-stream": "2.2.1"
       },
       "dependencies": {
         "glob": {
@@ -6503,11 +6511,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -6515,8 +6523,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-extglob": {
@@ -6529,7 +6537,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -6542,10 +6550,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -6558,8 +6566,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -6574,8 +6582,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       },
       "dependencies": {
         "process": {
@@ -6590,7 +6598,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -6598,9 +6606,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -6608,11 +6616,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       },
       "dependencies": {
         "expand-tilde": {
@@ -6620,7 +6628,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -6635,11 +6643,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -6654,9 +6662,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
       "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2"
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4"
       }
     },
     "glogg": {
@@ -6664,7 +6672,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "got": {
@@ -6672,17 +6680,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "gotrue-js": {
@@ -6690,7 +6698,7 @@
       "resolved": "https://registry.npmjs.org/gotrue-js/-/gotrue-js-0.9.22.tgz",
       "integrity": "sha512-i7onzXLP41YHs/S6LFk7mactBSIBb/Xib1dsvYMYu4e45HVLJlEYW1u016DVbh5mMFtyCace6QUbC7lHpG/hNw==",
       "requires": {
-        "micro-api-client": "^3.2.1"
+        "micro-api-client": "3.2.3"
       }
     },
     "graceful-fs": {
@@ -6721,8 +6729,8 @@
       "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-1.0.11.tgz",
       "integrity": "sha1-xpcNEb3+eqAB+WyLpBuak6bcgFw=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "graphql": "^0.11.7"
+        "babel-runtime": "6.26.0",
+        "graphql": "0.11.7"
       }
     },
     "graphql-type-json": {
@@ -6735,10 +6743,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.10.0",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.12.0",
+        "kind-of": "5.1.0",
+        "strip-bom-string": "1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -6751,7 +6759,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "js-yaml": {
@@ -6759,8 +6767,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         },
         "kind-of": {
@@ -6780,10 +6788,10 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "requires": {
-        "archive-type": "^3.0.0",
-        "decompress": "^3.0.0",
-        "gulp-util": "^3.0.1",
-        "readable-stream": "^2.0.2"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.6"
       }
     },
     "gulp-rename": {
@@ -6796,11 +6804,11 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -6808,7 +6816,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -6818,24 +6826,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "lodash.keys": {
@@ -6843,9 +6851,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "requires": {
-            "lodash._getnative": "^3.0.0",
-            "lodash.isarguments": "^3.0.0",
-            "lodash.isarray": "^3.0.0"
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
           }
         },
         "lodash.template": {
@@ -6853,15 +6861,15 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
           "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash._basetostring": "^3.0.0",
-            "lodash._basevalues": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0",
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0",
-            "lodash.keys": "^3.0.0",
-            "lodash.restparam": "^3.0.0",
-            "lodash.templatesettings": "^3.0.0"
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
           }
         },
         "lodash.templatesettings": {
@@ -6869,8 +6877,8 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
           "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
           "requires": {
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0"
           }
         },
         "minimist": {
@@ -6893,8 +6901,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -6905,7 +6913,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "gzip-size": {
@@ -6913,7 +6921,7 @@
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "requires": {
-        "duplexer": "^0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "har-schema": {
@@ -6926,8 +6934,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -6935,7 +6943,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -6943,7 +6951,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -6976,7 +6984,7 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "has-symbol-support-x": {
@@ -6989,7 +6997,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -7002,9 +7010,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7019,8 +7027,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7028,7 +7036,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7036,7 +7044,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7046,7 +7054,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7056,8 +7064,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -7065,8 +7073,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hast-to-hyperscript": {
@@ -7074,13 +7082,13 @@
       "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-3.1.0.tgz",
       "integrity": "sha512-/At2y6sQLTAcL6y+3hRQFcaBoRlKrmHSpvvdOZqRz6uI2YyjrU8rJ7e1LbmLtWUmzaIqKEdNSku+AJC0pt4+aw==",
       "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "is-nan": "^1.2.1",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "is-nan": "1.2.1",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
         "trim": "0.0.1",
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "hast-util-embedded": {
@@ -7088,7 +7096,7 @@
       "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.1.tgz",
       "integrity": "sha512-VreBCMxmSRCT7OjZihrth3ByA9GtLKbRyoDJafP/1vxAxx+VNdhHKKADCSIyMGvrvTExVRqU/BnVq51dxMLAeQ==",
       "requires": {
-        "hast-util-is-element": "^1.0.0"
+        "hast-util-is-element": "1.0.1"
       }
     },
     "hast-util-from-parse5": {
@@ -7096,11 +7104,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-1.1.0.tgz",
       "integrity": "sha1-NZzDOdyMzx36ykGRWtY/1UYTCs0=",
       "requires": {
-        "camelcase": "^3.0.0",
-        "has": "^1.0.1",
-        "hastscript": "^3.0.0",
-        "property-information": "^3.1.0",
-        "vfile-location": "^2.0.0"
+        "camelcase": "3.0.0",
+        "has": "1.0.3",
+        "hastscript": "3.1.0",
+        "property-information": "3.2.0",
+        "vfile-location": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -7120,8 +7128,8 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.1.tgz",
       "integrity": "sha512-qFDY0oz0lbc0DOcy61BSgJo+wi/ykFs4p95YjrtRP81eNfmBPs/Z0j4WLFmepJ6znfxLlRcPpic8FOdzCD5aKw==",
       "requires": {
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0"
+        "hast-util-has-property": "1.0.1",
+        "hast-util-is-element": "1.0.1"
       }
     },
     "hast-util-is-element": {
@@ -7139,13 +7147,13 @@
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-2.0.2.tgz",
       "integrity": "sha512-ujytXSAZC85bvh38f8ALzfE2IZDdCwB9XeHUs9l20C1p4/1YeAoZqq9z9U17vWQ9hMmqbVaROuSK8feL3wTCJg==",
       "requires": {
-        "hast-util-from-parse5": "^2.0.0",
-        "hast-util-to-parse5": "^2.0.0",
-        "html-void-elements": "^1.0.1",
-        "parse5": "^3.0.3",
-        "unist-util-position": "^3.0.0",
-        "web-namespaces": "^1.0.0",
-        "zwitch": "^1.0.0"
+        "hast-util-from-parse5": "2.1.0",
+        "hast-util-to-parse5": "2.2.0",
+        "html-void-elements": "1.0.3",
+        "parse5": "3.0.3",
+        "unist-util-position": "3.0.1",
+        "web-namespaces": "1.1.2",
+        "zwitch": "1.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -7158,10 +7166,10 @@
           "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-2.1.0.tgz",
           "integrity": "sha1-9hI9g9NoljCwl+E+Qw0W2dG9iIQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "hastscript": "^3.0.0",
-            "property-information": "^3.1.0",
-            "vfile-location": "^2.0.0"
+            "camelcase": "3.0.0",
+            "hastscript": "3.1.0",
+            "property-information": "3.2.0",
+            "vfile-location": "2.0.3"
           }
         },
         "parse5": {
@@ -7169,7 +7177,7 @@
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "requires": {
-            "@types/node": "*"
+            "@types/node": "7.0.68"
           }
         }
       }
@@ -7179,17 +7187,17 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
       "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
       "requires": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.1.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-is-element": "1.0.1",
+        "hast-util-whitespace": "1.0.1",
+        "html-void-elements": "1.0.3",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
+        "stringify-entities": "1.3.2",
+        "unist-util-is": "2.1.2",
+        "xtend": "4.0.1"
       }
     },
     "hast-util-to-mdast": {
@@ -7197,13 +7205,13 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-1.2.0.tgz",
       "integrity": "sha512-kYrD+weqqtBwqLHkEMh12YHXPzG1iuRm9NH3qVs7hwGTkE5QrhtdMahVN96JnRnb/MmdvfKCzK42ajgRKjQzNg==",
       "requires": {
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-to-string": "^1.0.0",
-        "rehype-minify-whitespace": "^2.0.0",
-        "unist-util-is": "^2.1.0",
-        "unist-util-visit": "^1.1.1",
-        "xtend": "^4.0.1"
+        "hast-util-has-property": "1.0.1",
+        "hast-util-is-element": "1.0.1",
+        "hast-util-to-string": "1.0.1",
+        "rehype-minify-whitespace": "2.0.3",
+        "unist-util-is": "2.1.2",
+        "unist-util-visit": "1.4.0",
+        "xtend": "4.0.1"
       }
     },
     "hast-util-to-parse5": {
@@ -7211,11 +7219,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-2.2.0.tgz",
       "integrity": "sha512-Eg1mrf0VTT/PipFN5z1+mVi+4GNhinKk/i/HKeX1h17IYiMdm3G8vgA0FU04XCuD1cWV58f5zziFKcBkr+WuKw==",
       "requires": {
-        "hast-to-hyperscript": "^3.0.0",
-        "mapz": "^1.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
-        "zwitch": "^1.0.0"
+        "hast-to-hyperscript": "3.1.0",
+        "mapz": "1.0.2",
+        "web-namespaces": "1.1.2",
+        "xtend": "4.0.1",
+        "zwitch": "1.0.3"
       }
     },
     "hast-util-to-string": {
@@ -7233,11 +7241,11 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-3.1.0.tgz",
       "integrity": "sha512-8V34dMSDT1Ik+ZSgTzCLdyp89MrWxcxctXPxhmb72GQj1Xkw1aHPM9UaHCWewvH2Q+PVkYUm4ZJVw4T0dgEGNA==",
       "requires": {
-        "camelcase": "^3.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0"
+        "camelcase": "3.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-parse-selector": "2.2.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2"
       },
       "dependencies": {
         "camelcase": {
@@ -7252,10 +7260,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       },
       "dependencies": {
         "hoek": {
@@ -7275,11 +7283,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
       }
     },
     "hmac-drbg": {
@@ -7287,9 +7295,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.5",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -7307,8 +7315,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -7316,7 +7324,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -7339,13 +7347,13 @@
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.19.tgz",
       "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.1.x",
-        "commander": "2.16.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.16.0",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.4.6"
       },
       "dependencies": {
         "commander": {
@@ -7363,8 +7371,8 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
           "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
           "requires": {
-            "commander": "~2.16.0",
-            "source-map": "~0.6.1"
+            "commander": "2.16.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -7379,9 +7387,9 @@
       "resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.4.tgz",
       "integrity": "sha512-E8kVXb/WcRyBD2+s11HThFedq0CWKWQ2jMY122W5r/aCAfLcJKUc0kyV5bQg0tFHipKNmqcNy94DFRmXHNhSTA==",
       "requires": {
-        "glob": "^7.1.2",
-        "minimatch": "^3.0.4",
-        "slash": "^1.0.0"
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "slash": "1.0.0"
       }
     },
     "html-webpack-plugin": {
@@ -7389,12 +7397,12 @@
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "requires": {
-        "bluebird": "^3.4.7",
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "toposort": "^1.0.0"
+        "bluebird": "3.5.1",
+        "html-minifier": "3.5.19",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.10",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.7"
       }
     },
     "html-whitespace-sensitive-tag-names": {
@@ -7407,10 +7415,10 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -7418,7 +7426,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "isarray": {
@@ -7431,10 +7439,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -7449,10 +7457,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -7465,9 +7473,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.2",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -7475,10 +7483,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.17.0",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.10",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -7491,7 +7499,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -7501,9 +7509,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "https-browserify": {
@@ -7536,12 +7544,12 @@
       "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "requires": {
-        "file-type": "^4.1.0",
-        "globby": "^6.1.0",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^2.3.0",
-        "replace-ext": "^1.0.0"
+        "file-type": "4.4.0",
+        "globby": "6.1.0",
+        "make-dir": "1.3.0",
+        "p-pipe": "1.2.0",
+        "pify": "2.3.0",
+        "replace-ext": "1.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7556,9 +7564,9 @@
       "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-5.0.1.tgz",
       "integrity": "sha1-2KMp2lU6+iJrEc5i3r4Lfje0OeY=",
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-png": "^1.0.0",
-        "pngquant-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-png": "1.1.0",
+        "pngquant-bin": "3.1.1"
       }
     },
     "imagemin-webp": {
@@ -7566,9 +7574,9 @@
       "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.1.0.tgz",
       "integrity": "sha1-7/0AFg2EVrlcveX9JsMtZLAxgGI=",
       "requires": {
-        "cwebp-bin": "^4.0.0",
-        "exec-buffer": "^3.0.0",
-        "is-cwebp-readable": "^2.0.1"
+        "cwebp-bin": "4.0.0",
+        "exec-buffer": "3.2.0",
+        "is-cwebp-readable": "2.0.1"
       }
     },
     "immediate": {
@@ -7601,7 +7609,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -7619,8 +7627,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -7638,8 +7646,8 @@
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
       "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
       "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
+        "bowser": "1.9.4",
+        "css-in-js-utils": "2.0.1"
       }
     },
     "inquirer": {
@@ -7647,20 +7655,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7673,7 +7681,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -7681,9 +7689,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -7696,7 +7704,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -7704,7 +7712,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7719,7 +7727,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -7742,8 +7750,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       },
       "dependencies": {
         "is-relative": {
@@ -7751,7 +7759,7 @@
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
           "requires": {
-            "is-unc-path": "^1.0.0"
+            "is-unc-path": "1.0.0"
           }
         }
       }
@@ -7766,7 +7774,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-alphabetical": {
@@ -7784,8 +7792,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-arrayish": {
@@ -7798,7 +7806,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -7811,7 +7819,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-bzip2": {
@@ -7829,7 +7837,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-cwebp-readable": {
@@ -7837,7 +7845,7 @@
       "resolved": "https://registry.npmjs.org/is-cwebp-readable/-/is-cwebp-readable-2.0.1.tgz",
       "integrity": "sha1-r7k7DAq9CiUQEBauM66ort+SbSY=",
       "requires": {
-        "file-type": "^4.3.0"
+        "file-type": "4.4.0"
       }
     },
     "is-data-descriptor": {
@@ -7845,7 +7853,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-decimal": {
@@ -7858,9 +7866,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7885,7 +7893,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -7903,7 +7911,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -7921,7 +7929,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-gzip": {
@@ -7949,8 +7957,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-nan": {
@@ -7958,7 +7966,7 @@
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
       "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
       "requires": {
-        "define-properties": "^1.1.1"
+        "define-properties": "1.1.2"
       }
     },
     "is-natural-number": {
@@ -7976,7 +7984,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -7999,7 +8007,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -8007,7 +8015,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -8020,7 +8028,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8060,7 +8068,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "^0.1.1"
+        "is-unc-path": "0.1.2"
       },
       "dependencies": {
         "is-unc-path": {
@@ -8068,7 +8076,7 @@
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
           "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
           "requires": {
-            "unc-path-regex": "^0.1.0"
+            "unc-path-regex": "0.1.2"
           }
         }
       }
@@ -8078,7 +8086,7 @@
       "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
       "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
       "requires": {
-        "is-absolute-url": "^2.0.0"
+        "is-absolute-url": "2.1.0"
       }
     },
     "is-retry-allowed": {
@@ -8101,7 +8109,7 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-tar": {
@@ -8119,7 +8127,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -8177,7 +8185,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
       "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.1"
       }
     },
     "isexe": {
@@ -8208,8 +8216,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -8222,8 +8230,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "items": {
@@ -8241,22 +8249,22 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "bignumber.js": "^2.1.0",
+        "bignumber.js": "2.4.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "^3.0.2",
-        "exif-parser": "^0.1.9",
-        "file-type": "^3.1.0",
-        "jpeg-js": "^0.2.0",
-        "load-bmfont": "^1.2.3",
-        "mime": "^1.3.4",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.6.0",
         "mkdirp": "0.5.1",
-        "pixelmatch": "^4.0.0",
-        "pngjs": "^3.0.0",
-        "read-chunk": "^1.0.1",
-        "request": "^2.65.0",
-        "stream-to-buffer": "^0.1.0",
-        "tinycolor2": "^1.1.2",
-        "url-regex": "^3.0.0"
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.3",
+        "read-chunk": "1.0.1",
+        "request": "2.87.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -8276,9 +8284,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
       "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
       "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
+        "hoek": "4.2.1",
+        "isemail": "3.1.3",
+        "topo": "2.0.2"
       }
     },
     "jpeg-js": {
@@ -8301,8 +8309,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "jsan": {
@@ -8341,7 +8349,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -8364,7 +8372,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -8378,27 +8386,27 @@
       "integrity": "sha512-LQE/RbnkX00T6crRORvGumoMm5nLrPFU3nYdEax9KF3KE1L03fyO7bkuOyvF6u7QUg/PttLSrXCM2DOIvTUyoA==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "chalk": "^1.1.1",
-        "core-js": "^1.2.6",
-        "glob": "^6.0.1",
-        "graceful-fs": "^4.1.2",
-        "jspm-github": "^0.14.11",
-        "jspm-npm": "^0.30.3",
-        "jspm-registry": "^0.4.1",
-        "liftoff": "^2.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "ncp": "^2.0.0",
-        "proper-lockfile": "^1.1.2",
-        "request": "^2.67.0",
-        "rimraf": "^2.4.4",
-        "sane": "^1.3.3",
-        "semver": "^5.1.0",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "core-js": "1.2.7",
+        "glob": "6.0.4",
+        "graceful-fs": "4.1.11",
+        "jspm-github": "0.14.13",
+        "jspm-npm": "0.30.4",
+        "jspm-registry": "0.4.4",
+        "liftoff": "2.5.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "proper-lockfile": "1.2.0",
+        "request": "2.87.0",
+        "rimraf": "2.6.2",
+        "sane": "1.7.0",
+        "semver": "5.5.0",
         "systemjs": "0.21.3",
         "systemjs-builder": "0.16.13",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "core-js": {
@@ -8413,11 +8421,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "optional": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -8428,16 +8436,16 @@
       "integrity": "sha1-Mm5SF9NjmyFgkpOwHn4Yd13T3Mc=",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "expand-tilde": "^1.2.0",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "netrc": "^0.1.3",
-        "request": "^2.74.0",
-        "rimraf": "^2.5.4",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
-        "which": "^1.0.9"
+        "bluebird": "3.5.1",
+        "expand-tilde": "1.2.2",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "netrc": "0.1.4",
+        "request": "2.87.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.3",
+        "which": "1.3.1"
       }
     },
     "jspm-npm": {
@@ -8446,16 +8454,16 @@
       "integrity": "sha512-Gx9/HGtbV4igvvAzhI8rGSzUIUIZtIK5kA7yf+5dGqmbD6hUUK29OxhbF7y/xXmpqyJ7iwiEY5vIszT5rPaz+A==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "buffer-peek-stream": "^1.0.1",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "readdirp": "^2.0.0",
-        "request": "^2.58.0",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
+        "bluebird": "3.5.1",
+        "buffer-peek-stream": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "readdirp": "2.1.0",
+        "request": "2.87.0",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.3",
         "traceur": "0.0.105",
-        "which": "^1.1.1"
+        "which": "1.3.1"
       }
     },
     "jspm-registry": {
@@ -8464,10 +8472,10 @@
       "integrity": "sha1-1TFmA1qHzc5YXWK6o5dWhUaZbXA=",
       "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "rimraf": "^2.3.2",
-        "rsvp": "^3.0.18",
-        "semver": "^4.3.3"
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6"
       },
       "dependencies": {
         "semver": {
@@ -8509,7 +8517,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "latest-version": {
@@ -8517,7 +8525,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -8535,7 +8543,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcid": {
@@ -8543,7 +8551,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "leven": {
@@ -8556,7 +8564,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "liftoff": {
@@ -8565,14 +8573,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.2",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.8.1"
       }
     },
     "linked-list": {
@@ -8586,12 +8594,12 @@
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.0",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
+        "mime": "1.6.0",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.5.0",
+        "xtend": "4.0.1"
       }
     },
     "load-json-file": {
@@ -8599,10 +8607,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8617,10 +8625,10 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "localforage": {
@@ -8636,8 +8644,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -8660,7 +8668,7 @@
       "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
       "integrity": "sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==",
       "requires": {
-        "lodash": "^4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "lodash._basecopy": {
@@ -8748,7 +8756,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.escaperegexp": {
@@ -8801,7 +8809,7 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.isplainobject": {
@@ -8884,8 +8892,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -8893,7 +8901,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lodash.toarray": {
@@ -8911,7 +8919,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "logalot": {
@@ -8919,8 +8927,8 @@
       "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       },
       "dependencies": {
         "figures": {
@@ -8928,8 +8936,8 @@
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -8949,7 +8957,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -8957,8 +8965,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowdb": {
@@ -8966,10 +8974,10 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.16.2.tgz",
       "integrity": "sha1-oql262bsV3lykZcPPIfNthEm+jo=",
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "steno": "^0.4.1"
+        "graceful-fs": "4.1.11",
+        "is-promise": "2.1.0",
+        "lodash": "4.17.10",
+        "steno": "0.4.4"
       }
     },
     "lower-case": {
@@ -8987,10 +8995,10 @@
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       }
     },
     "lru-cache": {
@@ -8998,8 +9006,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "ltcdr": {
@@ -9012,7 +9020,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-iterator": {
@@ -9021,7 +9029,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "optional": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9038,7 +9046,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "optional": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-cache": {
@@ -9056,7 +9064,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mapz": {
@@ -9064,7 +9072,7 @@
       "resolved": "https://registry.npmjs.org/mapz/-/mapz-1.0.2.tgz",
       "integrity": "sha512-NuY43BoHy5K4jVg3/oD+g8ysNwdXY3HB5UankVWoikxT9YMqgCYC77pNRENTm/DfslLxPFEOyJUw9h9isRty6w==",
       "requires": {
-        "x-is-array": "^0.1.0"
+        "x-is-array": "0.1.0"
       }
     },
     "markdown-escapes": {
@@ -9092,9 +9100,9 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
       }
     },
     "md5-file": {
@@ -9102,7 +9110,7 @@
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
       "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
       "requires": {
-        "buffer-alloc": "^1.1.0"
+        "buffer-alloc": "1.2.0"
       }
     },
     "md5.js": {
@@ -9110,8 +9118,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "mdast-util-compact": {
@@ -9119,8 +9127,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit": "1.4.0"
       }
     },
     "mdast-util-definitions": {
@@ -9128,7 +9136,7 @@
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
       "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
       "requires": {
-        "unist-util-visit": "^1.0.0"
+        "unist-util-visit": "1.4.0"
       }
     },
     "mdast-util-to-hast": {
@@ -9136,17 +9144,17 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
       "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
+        "collapse-white-space": "1.0.4",
+        "detab": "2.0.1",
+        "mdast-util-definitions": "1.2.2",
+        "mdurl": "1.0.1",
         "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
+        "trim-lines": "1.1.1",
+        "unist-builder": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.4.0",
+        "xtend": "4.0.1"
       }
     },
     "mdast-util-to-nlcst": {
@@ -9154,10 +9162,10 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.0.tgz",
       "integrity": "sha1-2tJihXZY0eq0tYFKIOL5PXyh47Y=",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "repeat-string": "^1.5.2",
-        "unist-util-position": "^3.0.0",
-        "vfile-location": "^2.0.0"
+        "nlcst-to-string": "2.0.2",
+        "repeat-string": "1.6.1",
+        "unist-util-position": "3.0.1",
+        "vfile-location": "2.0.3"
       }
     },
     "mdast-util-to-string": {
@@ -9170,9 +9178,9 @@
       "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-2.0.1.tgz",
       "integrity": "sha1-sdLLI7+wH4Evp7Vb/+iwqL7fbyE=",
       "requires": {
-        "github-slugger": "^1.1.1",
-        "mdast-util-to-string": "^1.0.2",
-        "unist-util-visit": "^1.1.0"
+        "github-slugger": "1.2.0",
+        "mdast-util-to-string": "1.0.4",
+        "unist-util-visit": "1.4.0"
       }
     },
     "mdurl": {
@@ -9190,7 +9198,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -9198,8 +9206,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -9207,16 +9215,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -9224,11 +9232,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "minimist": {
@@ -9241,9 +9249,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -9256,9 +9264,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -9266,8 +9274,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -9275,7 +9283,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -9295,7 +9303,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "methods": {
@@ -9313,19 +9321,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -9333,8 +9341,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -9352,7 +9360,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "1.35.0"
       }
     },
     "mimic-fn": {
@@ -9370,7 +9378,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "mini-svg-data-uri": {
@@ -9393,7 +9401,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -9406,8 +9414,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
       "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -9422,7 +9430,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "mitt": {
@@ -9435,8 +9443,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -9444,7 +9452,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -9480,7 +9488,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "requires": {
-            "readable-stream": "~1.1.9"
+            "readable-stream": "1.1.14"
           }
         },
         "isarray": {
@@ -9493,10 +9501,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -9526,17 +9534,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -9572,74 +9580,74 @@
       "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-1.9.3.tgz",
       "integrity": "sha512-DNhD5BK7VaJ3zWTXOkcqwCIZUq061PUOGHFj43y6udUPsbDD0cTzB9J9EH4loNzuR3MTW+mTESmKmU55jVaVvw==",
       "requires": {
-        "classnames": "^2.2.5",
-        "create-react-class": "^15.6.0",
-        "diacritics": "^1.3.0",
-        "fsevents": "^1.0.14",
-        "fuzzy": "^0.1.1",
-        "gotrue-js": "^0.9.15",
-        "gray-matter": "^3.0.6",
-        "history": "^4.7.2",
-        "immutable": "^3.7.6",
-        "is-hotkey": "^0.1.1",
-        "js-base64": "^2.1.9",
-        "js-yaml": "^3.10.0",
-        "jwt-decode": "^2.1.0",
-        "localforage": "^1.4.2",
-        "lodash": "^4.13.1",
-        "mdast-util-definitions": "^1.2.2",
-        "mdast-util-to-string": "^1.0.4",
-        "moment": "^2.11.2",
-        "prop-types": "^15.5.10",
-        "react": "^16.0.0",
-        "react-aria-menubutton": "^5.1.0",
-        "react-autosuggest": "^9.3.2",
-        "react-datetime": "^2.11.0",
-        "react-dnd": "^2.5.4",
-        "react-dnd-html5-backend": "^2.5.4",
-        "react-dom": "^16.0.0",
-        "react-frame-component": "^2.0.0",
-        "react-hot-loader": "^4.0.0",
-        "react-immutable-proptypes": "^2.1.0",
+        "classnames": "2.2.6",
+        "create-react-class": "15.6.3",
+        "diacritics": "1.3.0",
+        "fsevents": "1.2.4",
+        "fuzzy": "0.1.3",
+        "gotrue-js": "0.9.22",
+        "gray-matter": "3.1.1",
+        "history": "4.7.2",
+        "immutable": "3.7.6",
+        "is-hotkey": "0.1.2",
+        "js-base64": "2.4.8",
+        "js-yaml": "3.12.0",
+        "jwt-decode": "2.2.0",
+        "localforage": "1.7.2",
+        "lodash": "4.17.10",
+        "mdast-util-definitions": "1.2.2",
+        "mdast-util-to-string": "1.0.4",
+        "moment": "2.22.2",
+        "prop-types": "15.6.2",
+        "react": "16.4.2",
+        "react-aria-menubutton": "5.1.1",
+        "react-autosuggest": "9.3.4",
+        "react-datetime": "2.15.0",
+        "react-dnd": "2.6.0",
+        "react-dnd-html5-backend": "2.6.0",
+        "react-dom": "16.4.2",
+        "react-frame-component": "2.0.2",
+        "react-hot-loader": "4.3.4",
+        "react-immutable-proptypes": "2.1.0",
         "react-is": "16.3.1",
-        "react-modal": "^3.1.5",
-        "react-redux": "^4.4.0",
-        "react-router-dom": "^4.2.2",
-        "react-router-redux": "^5.0.0-alpha.8",
-        "react-scroll-sync": "^0.4.0",
-        "react-sortable-hoc": "^0.6.8",
-        "react-split-pane": "^0.1.66",
-        "react-textarea-autosize": "^5.2.0",
-        "react-toggled": "^1.1.2",
-        "react-topbar-progress-indicator": "^2.0.0",
-        "react-transition-group": "^2.2.1",
-        "react-waypoint": "^7.1.0",
-        "redux": "^3.3.1",
-        "redux-notifications": "^4.0.1",
-        "redux-optimist": "^0.0.2",
-        "redux-thunk": "^1.0.3",
-        "rehype-parse": "^3.1.0",
-        "rehype-remark": "^2.0.0",
-        "rehype-stringify": "^3.0.0",
-        "remark-parse": "^3.0.1",
-        "remark-rehype": "^2.0.0",
-        "remark-stringify": "^3.0.1",
-        "sanitize-filename": "^1.6.1",
-        "semaphore": "^1.0.5",
-        "slate": "^0.30.0",
-        "slate-edit-list": "^0.10.1",
-        "slate-edit-table": "^0.12.0",
-        "slate-plain-serializer": "^0.4.0",
+        "react-modal": "3.5.1",
+        "react-redux": "4.4.9",
+        "react-router-dom": "4.3.1",
+        "react-router-redux": "5.0.0-alpha.9",
+        "react-scroll-sync": "0.4.1",
+        "react-sortable-hoc": "0.6.8",
+        "react-split-pane": "0.1.82",
+        "react-textarea-autosize": "5.2.1",
+        "react-toggled": "1.2.7",
+        "react-topbar-progress-indicator": "2.0.0",
+        "react-transition-group": "2.4.0",
+        "react-waypoint": "7.3.4",
+        "redux": "3.7.2",
+        "redux-notifications": "4.0.1",
+        "redux-optimist": "0.0.2",
+        "redux-thunk": "1.0.3",
+        "rehype-parse": "3.1.0",
+        "rehype-remark": "2.1.0",
+        "rehype-stringify": "3.0.0",
+        "remark-parse": "3.0.1",
+        "remark-rehype": "2.0.1",
+        "remark-stringify": "3.0.1",
+        "sanitize-filename": "1.6.1",
+        "semaphore": "1.1.0",
+        "slate": "0.30.7",
+        "slate-edit-list": "0.10.3",
+        "slate-edit-table": "0.12.0",
+        "slate-plain-serializer": "0.4.16",
         "slate-react": "0.10.11",
-        "slate-soft-break": "^0.6.0",
-        "toml-j0.4": "^1.1.1",
-        "tomlify-j0.4": "^3.0.0-alpha.0",
-        "unified": "^6.1.4",
-        "unist-builder": "^1.0.2",
-        "unist-util-visit-parents": "^1.1.1",
-        "url": "^0.11.0",
-        "uuid": "^3.1.0",
-        "what-input": "^5.0.3"
+        "slate-soft-break": "0.6.1",
+        "toml-j0.4": "1.1.1",
+        "tomlify-j0.4": "3.0.0",
+        "unified": "6.2.0",
+        "unist-builder": "1.0.2",
+        "unist-util-visit-parents": "1.1.2",
+        "url": "0.11.0",
+        "uuid": "3.3.2",
+        "what-input": "5.1.1"
       },
       "dependencies": {
         "esprima": {
@@ -9652,8 +9660,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         },
         "react-dom": {
@@ -9661,10 +9669,10 @@
           "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
           "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
           "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
+            "fbjs": "0.8.17",
+            "loose-envify": "1.4.0",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.2"
           }
         },
         "react-hot-loader": {
@@ -9672,12 +9680,12 @@
           "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.3.4.tgz",
           "integrity": "sha512-LlKjtHq+RhDq9xm6crXojbkzrEvli5F4/RaeJ//XtDWrwwsAHDjEqKfZZiPCxv7gWV2cxE3YE8TXeE9BDzLqOA==",
           "requires": {
-            "fast-levenshtein": "^2.0.6",
-            "global": "^4.3.0",
-            "hoist-non-react-statics": "^2.5.0",
-            "prop-types": "^15.6.1",
-            "react-lifecycles-compat": "^3.0.4",
-            "shallowequal": "^1.0.2"
+            "fast-levenshtein": "2.0.6",
+            "global": "4.3.2",
+            "hoist-non-react-statics": "2.5.5",
+            "prop-types": "15.6.2",
+            "react-lifecycles-compat": "3.0.4",
+            "shallowequal": "1.1.0"
           }
         }
       }
@@ -9708,7 +9716,7 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node-abi": {
@@ -9716,7 +9724,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-emoji": {
@@ -9724,7 +9732,7 @@
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash.toarray": "4.4.0"
       }
     },
     "node-eta": {
@@ -9737,8 +9745,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-gyp": {
@@ -9746,18 +9754,18 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
       "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": ">=2.9.0 <2.82.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "2.0.3",
+        "osenv": "0.1.5",
+        "request": "2.81.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.1"
       },
       "dependencies": {
         "ajv": {
@@ -9765,8 +9773,8 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "assert-plus": {
@@ -9784,9 +9792,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.19"
           }
         },
         "har-schema": {
@@ -9799,8 +9807,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "http-signature": {
@@ -9808,9 +9816,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
           }
         },
         "performance-now": {
@@ -9828,28 +9836,28 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.19",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "semver": {
@@ -9869,28 +9877,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.4",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -9906,25 +9914,25 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
       "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.3.1",
-        "npmlog": "^4.0.0",
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.3",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.10.0",
+        "node-gyp": "3.7.0",
+        "npmlog": "4.1.2",
         "request": "2.87.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -9932,8 +9940,8 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "which": "1.3.1"
           }
         },
         "gauge": {
@@ -9941,14 +9949,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -9956,7 +9964,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "npmlog": {
@@ -9964,10 +9972,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "string-width": {
@@ -9975,9 +9983,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -9992,8 +10000,8 @@
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
+        "inherits": "2.0.3",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -10006,10 +10014,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -10029,7 +10037,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -10037,10 +10045,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -10048,7 +10056,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -10061,10 +10069,4167 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
+    "npm": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.10.0.tgz",
+      "integrity": "sha512-lvjvjgR5wG2RJ2uqak1xtZcVAWMwVOzN5HkUlUj/n8rU1f3A0fNn+7HwOzH9Lyf0Ppyu9ApgsEpHczOSnx1cwA==",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.0",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.2",
+        "cacache": "10.0.4",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "1.0.0",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.6.2",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.2",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.0.9",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.1",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "7.6.1",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.85.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "5.3.0",
+        "strip-ansi": "4.0.0",
+        "tar": "4.4.2",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bin-links": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "slide": "1.1.6"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "byte-size": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "10.0.4",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.2",
+            "mississippi": "2.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "5.3.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
+          },
+          "dependencies": {
+            "mississippi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "concat-stream": "1.6.1",
+                "duplexify": "3.5.4",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.6",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "duplexify": {
+                  "version": "3.5.4",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.6",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "flush-write-stream": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.6"
+                  }
+                },
+                "from2": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.6"
+                  }
+                },
+                "parallel-transform": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.6"
+                  },
+                  "dependencies": {
+                    "cyclist": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                },
+                "pumpify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "duplexify": "3.5.4",
+                    "inherits": "2.0.3",
+                    "pump": "2.0.1"
+                  }
+                },
+                "stream-each": {
+                  "version": "1.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.6",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "cli-table2": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "wcwidth": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
+              "dependencies": {
+                "defaults": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
+                  "dependencies": {
+                    "clone": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          },
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "bundled": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "bundled": true
+            }
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
+          },
+          "dependencies": {
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "1.0.6"
+          },
+          "dependencies": {
+            "cidr-regex": {
+              "version": "1.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "libcipm": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "bin-links": "1.1.0",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.1",
+            "npm-lifecycle": "2.0.1",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
+          },
+          "dependencies": {
+            "lock-verify": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "5.1.2",
+                "semver": "5.5.0"
+              },
+              "dependencies": {
+                "npm-package-arg": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "hosted-git-info": "2.6.0",
+                    "osenv": "0.1.5",
+                    "semver": "5.5.0",
+                    "validate-npm-package-name": "3.0.0"
+                  }
+                }
+              }
+            },
+            "npm-logical-tree": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "libnpx": {
+          "version": "10.2.0",
+          "bundled": true,
+          "requires": {
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  },
+                  "dependencies": {
+                    "locate-path": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                      },
+                      "dependencies": {
+                        "p-locate": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-limit": "1.2.0"
+                          },
+                          "dependencies": {
+                            "p-limit": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-try": "1.0.0"
+                              },
+                              "dependencies": {
+                                "p-try": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-exists": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "lcid": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "invert-kv": "1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "mem": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "mimic-fn": "1.2.0"
+                      },
+                      "dependencies": {
+                        "mimic-fn": {
+                          "version": "1.2.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lock-verify": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "lockfile": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._createset": {
+              "version": "4.0.3",
+              "bundled": true
+            },
+            "lodash._root": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "duplexify": {
+              "version": "3.5.4",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
+            },
+            "flush-write-stream": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "from2": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              }
+            },
+            "parallel-transform": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "cyclist": {
+                  "version": "0.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pump": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "pumpify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                }
+              }
+            },
+            "stream-each": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
+          },
+          "dependencies": {
+            "copy-concurrently": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+              }
+            },
+            "run-queue": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0"
+              }
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.6.2",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.85.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1"
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          },
+          "dependencies": {
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
+              "dependencies": {
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "cli-table2": "0.2.0",
+            "console-control-strings": "1.1.0"
+          },
+          "dependencies": {
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-package-arg": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          },
+          "dependencies": {
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "3.0.4"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "npm-profile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
+          },
+          "dependencies": {
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-registry-client": {
+          "version": "8.5.1",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.1",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.85.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.1",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            }
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "figgy-pudding": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.21"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.21",
+                          "bundled": true,
+                          "requires": {
+                            "safer-buffer": "2.1.2"
+                          },
+                          "dependencies": {
+                            "safer-buffer": {
+                              "version": "2.1.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "retry": {
+                      "version": "0.10.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              },
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "opener": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "pacote": {
+          "version": "7.6.1",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cacache": "10.0.4",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "2.6.0",
+            "minimatch": "3.0.4",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "5.3.0",
+            "tar": "4.4.2",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.4.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.0",
+                "lru-cache": "4.1.2",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.1",
+                    "duplexify": "3.5.4",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.1",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.4",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.4",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.2"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "npm-pick-manifest": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "6.1.0",
+                "semver": "5.5.0"
+              }
+            },
+            "promise-retry": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
+              "dependencies": {
+                "err-code": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "retry": {
+                  "version": "0.10.1",
+                  "bundled": true
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
+          },
+          "dependencies": {
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "strict-uri-encode": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            }
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
+          "dependencies": {
+            "util-extend": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
+          },
+          "dependencies": {
+            "json-parse-better-errors": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
+        },
+        "request": {
+          "version": "2.85.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "5.5.2",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "bundled": true
+                    },
+                    "fast-deep-equal": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "fast-json-stable-stringify": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "4.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                },
+                "cryptiles": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.1"
+                      }
+                    }
+                  }
+                },
+                "hoek": {
+                  "version": "4.2.1",
+                  "bundled": true
+                },
+                "sntp": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.1"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.3.0",
+                      "bundled": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "verror": {
+                      "version": "1.10.0",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.18",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.33.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.33.0",
+                  "bundled": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.4",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            }
+          }
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "sha": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-iterate": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "ssri": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "tar": {
+          "version": "4.4.2",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.4.1",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "term-size": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "2.4.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.1"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.1",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "5.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "3.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "configstore": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.2.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "make-dir": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "3.0.0"
+                  },
+                  "dependencies": {
+                    "pify": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "unique-string": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crypto-random-string": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "import-lazy": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-ci": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ci-info": "1.1.3"
+              },
+              "dependencies": {
+                "ci-info": {
+                  "version": "1.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.5"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "latest-version": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.2",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "6.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.2",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexer3": {
+                          "version": "0.1.4",
+                          "bundled": true
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "timed-out": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        },
+                        "unzip-response": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.7",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.5.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.7"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.5.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.5.0"
+              }
+            },
+            "xdg-basedir": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          },
+          "dependencies": {
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              },
+              "dependencies": {
+                "spdx-exceptions": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
+          "dependencies": {
+            "builtins": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.7"
+          },
+          "dependencies": {
+            "errno": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "prr": "1.0.1"
+              },
+              "dependencies": {
+                "prr": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -10072,7 +14237,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -10080,9 +14245,9 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
       "integrity": "sha1-Ag+ZNR8MAuOZxnS6JW58TTs90pg=",
       "requires": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.1.5",
+        "gauge": "1.2.7"
       }
     },
     "nth-check": {
@@ -10090,7 +14255,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-loader": {
@@ -10128,9 +14293,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -10138,7 +14303,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -10158,7 +14323,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10174,10 +14339,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "optional": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -10186,7 +14351,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "optional": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -10203,8 +14368,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "optional": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -10213,7 +14378,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "optional": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -10223,8 +14388,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -10232,7 +14397,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10260,7 +14425,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onecolor": {
@@ -10273,7 +14438,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "open": {
@@ -10286,7 +14451,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -10294,8 +14459,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.2"
       }
     },
     "ordered-read-streams": {
@@ -10303,8 +14468,8 @@
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
+        "is-stream": "1.1.0",
+        "readable-stream": "2.3.6"
       }
     },
     "original": {
@@ -10312,7 +14477,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
       "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
       "requires": {
-        "url-parse": "~1.4.0"
+        "url-parse": "1.4.3"
       }
     },
     "os-browserify": {
@@ -10335,9 +14500,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -10345,13 +14510,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -10366,8 +14531,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "output-file-sync": {
@@ -10375,9 +14540,9 @@
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-cancelable": {
@@ -10395,7 +14560,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -10403,7 +14568,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-map": {
@@ -10421,7 +14586,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -10434,10 +14599,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -10450,7 +14615,7 @@
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-asn1": {
@@ -10458,11 +14623,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-bmfont-ascii": {
@@ -10480,8 +14645,8 @@
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
       }
     },
     "parse-english": {
@@ -10489,10 +14654,10 @@
       "resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.1.tgz",
       "integrity": "sha512-g7hegR9AFIlGXl5645mG8nQeeWW7SrK7lgmgIWR0KKWvGyZO5mxa4GGoNxRLm6VW2LGpLnn6g4O9yyLJQ4IzQw==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "parse-latin": "^4.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "parse-latin": "4.1.1",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-entities": {
@@ -10500,12 +14665,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-filepath": {
@@ -10513,9 +14678,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -10523,10 +14688,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -10534,7 +14699,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "^0.3.2",
+        "for-each": "0.3.3",
         "trim": "0.0.1"
       }
     },
@@ -10543,7 +14708,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-latin": {
@@ -10551,9 +14716,9 @@
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.1.1.tgz",
       "integrity": "sha512-9fPVvDdw6G8LxL3o/PL6IzSGNGpF+3HEjCzFe0dN83sZPstftyr+McP9dNi3+EnR7ICYOHbHKCZ0l7JD90K5xQ==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-passwd": {
@@ -10571,7 +14736,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -10579,7 +14744,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -10632,7 +14797,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -10650,7 +14815,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -10665,11 +14830,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "pbkdf2-compat": {
@@ -10702,7 +14867,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pixelmatch": {
@@ -10710,7 +14875,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "requires": {
-        "pngjs": "^3.0.0"
+        "pngjs": "3.3.3"
       }
     },
     "pixrem": {
@@ -10718,9 +14883,9 @@
       "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
       "integrity": "sha1-MNG6+0w73Ojpu0vVahOYVhkyDDQ=",
       "requires": {
-        "browserslist": "^1.0.0",
-        "postcss": "^5.0.0",
-        "reduce-css-calc": "^1.2.7"
+        "browserslist": "1.7.7",
+        "postcss": "5.2.18",
+        "reduce-css-calc": "1.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -10728,8 +14893,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000872",
+            "electron-to-chromium": "1.3.55"
           }
         }
       }
@@ -10739,10 +14904,10 @@
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
       "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
       "requires": {
-        "find-up": "^1.0.0",
-        "load-json-file": "^1.1.0",
-        "object-assign": "^4.0.1",
-        "symbol": "^0.2.1"
+        "find-up": "1.1.2",
+        "load-json-file": "1.1.0",
+        "object-assign": "4.1.1",
+        "symbol": "0.2.3"
       },
       "dependencies": {
         "load-json-file": {
@@ -10750,11 +14915,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "pify": {
@@ -10767,7 +14932,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -10777,7 +14942,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-resolve": {
@@ -10786,8 +14951,8 @@
       "integrity": "sha1-Mpsudsy7Ny4i5qOkHLMKsEV4Nro=",
       "optional": true,
       "requires": {
-        "jspm": "^0.17.0-beta.13",
-        "resolve": "^1.1.7"
+        "jspm": "0.17.0-beta.48",
+        "resolve": "1.8.1"
       }
     },
     "pleeease-filters": {
@@ -10795,8 +14960,8 @@
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.1.tgz",
       "integrity": "sha1-Tf4OjxBGYTUXxktyi8gGCKfr8i8=",
       "requires": {
-        "onecolor": "~2.4.0",
-        "postcss": "^5.0.4"
+        "onecolor": "2.4.2",
+        "postcss": "5.2.18"
       }
     },
     "pngjs": {
@@ -10809,9 +14974,9 @@
       "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-3.1.1.tgz",
       "integrity": "sha1-0STZinWpSH9AwWQLTb/Lsr1aH9E=",
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "posix-character-classes": {
@@ -10824,10 +14989,10 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
+        "chalk": "1.1.3",
+        "js-base64": "2.4.8",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "supports-color": {
@@ -10835,7 +15000,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -10845,8 +15010,8 @@
       "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz",
       "integrity": "sha1-ovN8W9+ogeTBX08kXsDNlt0ucNU=",
       "requires": {
-        "balanced-match": "^0.4.1",
-        "postcss": "^5.0.21"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -10861,8 +15026,8 @@
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
       "integrity": "sha1-zrc3d+EGFn6yM/GTjJvZ8uaXMI0=",
       "requires": {
-        "postcss": "^5.1.1",
-        "postcss-selector-parser": "^2.2.0"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-browser-reporter": {
@@ -10870,7 +15035,7 @@
       "resolved": "https://registry.npmjs.org/postcss-browser-reporter/-/postcss-browser-reporter-0.5.0.tgz",
       "integrity": "sha1-rgad0IbVc4jRluHaw5y412Jv60g=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-calc": {
@@ -10878,9 +15043,9 @@
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
-        "postcss": "^5.0.2",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-css-calc": "^1.2.6"
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
       }
     },
     "postcss-color-function": {
@@ -10888,10 +15053,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz",
       "integrity": "sha1-mtIm9VDop8f4uKd4YFRbbdf1UkE=",
       "requires": {
-        "css-color-function": "^1.2.0",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-function": "1.3.3",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-gray": {
@@ -10899,10 +15064,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
       "integrity": "sha1-dEMu3mbdg7HRNjVlxos3bhj/Z3A=",
       "requires": {
-        "color": "^0.11.3",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-hex-alpha": {
@@ -10910,9 +15075,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
       "integrity": "sha1-RP1uyt5mAoZIyIHLZQTNy/3GzQk=",
       "requires": {
-        "color": "^0.10.1",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0"
+        "color": "0.10.1",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0"
       },
       "dependencies": {
         "color": {
@@ -10920,8 +15085,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
           "requires": {
-            "color-convert": "^0.5.3",
-            "color-string": "^0.3.0"
+            "color-convert": "0.5.3",
+            "color-string": "0.3.0"
           }
         },
         "color-convert": {
@@ -10936,9 +15101,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-1.0.5.tgz",
       "integrity": "sha1-9Tuxw0gxDOMHrYnjGBqGRzi15oc=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0",
-        "units-css": "^0.4.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "units-css": "0.4.0"
       }
     },
     "postcss-color-hwb": {
@@ -10946,10 +15111,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.1.tgz",
       "integrity": "sha1-1jr6+bcMtZX5AKKcn+V78qMvq+w=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-rebeccapurple": {
@@ -10957,8 +15122,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
       "integrity": "sha1-dMZETny7fYVhO19yht96SRYIRRw=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4"
+        "color": "0.11.4",
+        "postcss": "5.2.18"
       }
     },
     "postcss-color-rgb": {
@@ -10966,8 +15131,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-1.1.4.tgz",
       "integrity": "sha1-8pJD4i6OjBNDRHQJI3LUzmBb6Lw=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-rgba-fallback": {
@@ -10975,9 +15140,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz",
       "integrity": "sha1-bSlJG+WZCpMXPUfnx29YELCUAro=",
       "requires": {
-        "postcss": "^5.0.0",
-        "postcss-value-parser": "^3.0.2",
-        "rgb-hex": "^1.0.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "rgb-hex": "1.0.0"
       }
     },
     "postcss-colormin": {
@@ -10985,9 +15150,9 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
-        "colormin": "^1.0.5",
-        "postcss": "^5.0.13",
-        "postcss-value-parser": "^3.2.3"
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-convert-values": {
@@ -10995,8 +15160,8 @@
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
-        "postcss": "^5.0.11",
-        "postcss-value-parser": "^3.1.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-cssnext": {
@@ -11004,37 +15169,37 @@
       "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.11.0.tgz",
       "integrity": "sha1-MeaPAB5AlgTacDtm3hS4uMjJ8rE=",
       "requires": {
-        "autoprefixer": "^6.0.2",
-        "caniuse-api": "^1.5.3",
-        "chalk": "^1.1.1",
-        "pixrem": "^3.0.0",
-        "pleeease-filters": "^3.0.0",
-        "postcss": "^5.0.4",
-        "postcss-apply": "^0.3.0",
-        "postcss-attribute-case-insensitive": "^1.0.1",
-        "postcss-calc": "^5.0.0",
-        "postcss-color-function": "^2.0.0",
-        "postcss-color-gray": "^3.0.0",
-        "postcss-color-hex-alpha": "^2.0.0",
-        "postcss-color-hsl": "^1.0.5",
-        "postcss-color-hwb": "^2.0.0",
-        "postcss-color-rebeccapurple": "^2.0.0",
-        "postcss-color-rgb": "^1.1.4",
-        "postcss-color-rgba-fallback": "^2.0.0",
-        "postcss-custom-media": "^5.0.0",
-        "postcss-custom-properties": "^5.0.0",
-        "postcss-custom-selectors": "^3.0.0",
-        "postcss-font-family-system-ui": "^1.0.1",
-        "postcss-font-variant": "^2.0.0",
-        "postcss-image-set-polyfill": "^0.3.3",
-        "postcss-initial": "^1.3.1",
-        "postcss-media-minmax": "^2.1.0",
-        "postcss-nesting": "^2.0.5",
-        "postcss-pseudo-class-any-link": "^1.0.0",
-        "postcss-pseudoelements": "^3.0.0",
-        "postcss-replace-overflow-wrap": "^1.0.0",
-        "postcss-selector-matches": "^2.0.0",
-        "postcss-selector-not": "^2.0.0"
+        "autoprefixer": "6.7.7",
+        "caniuse-api": "1.6.1",
+        "chalk": "1.1.3",
+        "pixrem": "3.0.2",
+        "pleeease-filters": "3.0.1",
+        "postcss": "5.2.18",
+        "postcss-apply": "0.3.0",
+        "postcss-attribute-case-insensitive": "1.0.1",
+        "postcss-calc": "5.3.1",
+        "postcss-color-function": "2.0.1",
+        "postcss-color-gray": "3.0.1",
+        "postcss-color-hex-alpha": "2.0.0",
+        "postcss-color-hsl": "1.0.5",
+        "postcss-color-hwb": "2.0.1",
+        "postcss-color-rebeccapurple": "2.0.1",
+        "postcss-color-rgb": "1.1.4",
+        "postcss-color-rgba-fallback": "2.2.0",
+        "postcss-custom-media": "5.0.1",
+        "postcss-custom-properties": "5.0.2",
+        "postcss-custom-selectors": "3.0.0",
+        "postcss-font-family-system-ui": "1.0.2",
+        "postcss-font-variant": "2.0.1",
+        "postcss-image-set-polyfill": "0.3.5",
+        "postcss-initial": "1.5.3",
+        "postcss-media-minmax": "2.1.2",
+        "postcss-nesting": "2.3.1",
+        "postcss-pseudo-class-any-link": "1.0.0",
+        "postcss-pseudoelements": "3.0.0",
+        "postcss-replace-overflow-wrap": "1.0.0",
+        "postcss-selector-matches": "2.0.5",
+        "postcss-selector-not": "2.0.0"
       }
     },
     "postcss-custom-media": {
@@ -11042,7 +15207,7 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
       "integrity": "sha1-E40loYS/LrVN4S1VpsAcMKnYvYE=",
       "requires": {
-        "postcss": "^5.0.0"
+        "postcss": "5.2.18"
       }
     },
     "postcss-custom-properties": {
@@ -11050,8 +15215,8 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.2.tgz",
       "integrity": "sha1-lxnXjy2pz59TgQrrwj1GVhMKzrE=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -11066,9 +15231,9 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
       "integrity": "sha1-j4Ekn17Qeo0JF89qOf5bBWt/lqw=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0",
-        "postcss-selector-matches": "^2.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18",
+        "postcss-selector-matches": "2.0.5"
       },
       "dependencies": {
         "balanced-match": {
@@ -11083,7 +15248,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-duplicates": {
@@ -11091,7 +15256,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-empty": {
@@ -11099,7 +15264,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-overridden": {
@@ -11107,7 +15272,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-unused": {
@@ -11115,8 +15280,8 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-filter-plugins": {
@@ -11124,7 +15289,7 @@
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
       "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-font-family-system-ui": {
@@ -11132,9 +15297,9 @@
       "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-1.0.2.tgz",
       "integrity": "sha1-PhpeP7fjHl6ecUOcyw6AFFVpJ8c=",
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^5.2.12",
-        "postcss-value-parser": "^3.3.0"
+        "lodash": "4.17.10",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-font-variant": {
@@ -11142,7 +15307,7 @@
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
       "integrity": "sha1-fKKRA/WfoCyjrOLKIrL3VoU9Tvg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-image-set-polyfill": {
@@ -11150,8 +15315,8 @@
       "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-media-query-parser": "^0.2.3"
+        "postcss": "6.0.23",
+        "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11159,7 +15324,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -11167,9 +15332,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -11182,9 +15347,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11197,7 +15362,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11207,13 +15372,13 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-8.2.0.tgz",
       "integrity": "sha1-+S/SRU4h7077HnXADEesA/TROXw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pkg-resolve": "^0.1.7",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "promise-each": "^2.2.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
+        "object-assign": "4.1.1",
+        "pkg-resolve": "0.1.14",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "promise-each": "2.2.0",
+        "read-cache": "1.0.0",
+        "resolve": "1.8.1"
       }
     },
     "postcss-initial": {
@@ -11221,8 +15386,8 @@
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.3.tgz",
       "integrity": "sha1-IMPpHJaCLdsb7UlQjbltVrrDd9A=",
       "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^5.0.19"
+        "lodash.template": "4.4.0",
+        "postcss": "5.2.18"
       }
     },
     "postcss-loader": {
@@ -11230,8 +15395,8 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.13.0.tgz",
       "integrity": "sha1-cv2vDSlETfd9N1HOTmncQLyZ7YU=",
       "requires": {
-        "loader-utils": "^0.2.15",
-        "postcss": "^5.2.0"
+        "loader-utils": "0.2.17",
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-minmax": {
@@ -11239,7 +15404,7 @@
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
       "integrity": "sha1-RExc+JJqteT9iiUJ6Sl+dRZJzfg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-query-parser": {
@@ -11252,9 +15417,9 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-merge-longhand": {
@@ -11262,7 +15427,7 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-merge-rules": {
@@ -11270,11 +15435,11 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
-        "browserslist": "^1.5.2",
-        "caniuse-api": "^1.5.2",
-        "postcss": "^5.0.4",
-        "postcss-selector-parser": "^2.2.2",
-        "vendors": "^1.0.0"
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "browserslist": {
@@ -11282,8 +15447,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000872",
+            "electron-to-chromium": "1.3.55"
           }
         }
       }
@@ -11298,9 +15463,9 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-gradients": {
@@ -11308,8 +15473,8 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
-        "postcss": "^5.0.12",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-params": {
@@ -11317,10 +15482,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.2",
-        "postcss-value-parser": "^3.0.2",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -11328,10 +15493,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
-        "alphanum-sort": "^1.0.2",
-        "has": "^1.0.1",
-        "postcss": "^5.0.14",
-        "postcss-selector-parser": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-modules-extract-imports": {
@@ -11339,7 +15504,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11347,7 +15512,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -11355,9 +15520,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -11370,9 +15535,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11385,7 +15550,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11395,8 +15560,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11404,7 +15569,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -11412,9 +15577,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -11427,9 +15592,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11442,7 +15607,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11452,8 +15617,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11461,7 +15626,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -11469,9 +15634,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -11484,9 +15649,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11499,7 +15664,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11509,8 +15674,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11518,7 +15683,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -11526,9 +15691,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -11541,9 +15706,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11556,7 +15721,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11566,7 +15731,7 @@
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
       "integrity": "sha1-lKa2pO9wf77CCof+5clXdZtOAc8=",
       "requires": {
-        "postcss": "^5.0.19"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-charset": {
@@ -11574,7 +15739,7 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
-        "postcss": "^5.0.5"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-url": {
@@ -11582,10 +15747,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^1.4.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-ordered-values": {
@@ -11593,8 +15758,8 @@
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.1"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -11602,8 +15767,8 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
       "integrity": "sha1-kDI5GWQB0zX+c6x1YYb6YuaTryY=",
       "requires": {
-        "postcss": "^5.0.3",
-        "postcss-selector-parser": "^1.1.4"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "1.3.3"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -11611,9 +15776,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
           "integrity": "sha1-0u4Z33pk+O8hwacchvfUg1yIwoE=",
           "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "flatten": "1.0.2",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -11623,7 +15788,7 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz",
       "integrity": "sha1-bGghd8eQC6BTtt8X+MWQKEx7i7w=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-idents": {
@@ -11631,8 +15796,8 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-reduce-initial": {
@@ -11640,7 +15805,7 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-transforms": {
@@ -11648,9 +15813,9 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.8",
-        "postcss-value-parser": "^3.0.1"
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -11658,7 +15823,7 @@
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz",
       "integrity": "sha1-8KA7Meq5Y2ppNr/SEOKu8bQ0pkM=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reporter": {
@@ -11666,10 +15831,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
       "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
       "requires": {
-        "chalk": "^1.0.0",
-        "lodash": "^4.1.0",
-        "log-symbols": "^1.0.2",
-        "postcss": "^5.0.0"
+        "chalk": "1.1.3",
+        "lodash": "4.17.10",
+        "log-symbols": "1.0.2",
+        "postcss": "5.2.18"
       }
     },
     "postcss-selector-matches": {
@@ -11677,8 +15842,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
       "integrity": "sha1-+g9Dvle2jneqTNEYBwI0kqExAn8=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -11693,8 +15858,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
       "integrity": "sha1-xzrSGj91I0vuf+4mnhVP1qhpeY0=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -11709,9 +15874,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-svgo": {
@@ -11719,10 +15884,10 @@
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
-        "is-svg": "^2.0.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "svgo": "^0.7.0"
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
       }
     },
     "postcss-unique-selectors": {
@@ -11730,9 +15895,9 @@
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -11745,9 +15910,9 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "potrace": {
@@ -11755,7 +15920,7 @@
       "resolved": "https://registry.npmjs.org/potrace/-/potrace-2.1.1.tgz",
       "integrity": "sha1-eREahYGX82ZBiEX2Z/6Pf6wKeds=",
       "requires": {
-        "jimp": "^0.2.24"
+        "jimp": "0.2.28"
       }
     },
     "prebuild-install": {
@@ -11763,21 +15928,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
       "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.3",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.3",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
       },
       "dependencies": {
         "gauge": {
@@ -11785,14 +15950,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -11800,7 +15965,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "minimist": {
@@ -11813,10 +15978,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "pump": {
@@ -11824,8 +15989,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "string-width": {
@@ -11833,9 +15998,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -11866,8 +16031,8 @@
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
       }
     },
     "private": {
@@ -11880,12 +16045,12 @@
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz",
       "integrity": "sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==",
       "requires": {
-        "any-promise": "^1.3.0",
-        "deepmerge": "^2.0.1",
-        "inherits": "^2.0.3",
-        "next-tick": "^1.0.0",
-        "request": "^2.83.0",
-        "stream-parser": "~0.3.1"
+        "any-promise": "1.3.0",
+        "deepmerge": "2.1.1",
+        "inherits": "2.0.3",
+        "next-tick": "1.0.0",
+        "request": "2.87.0",
+        "stream-parser": "0.3.1"
       },
       "dependencies": {
         "any-promise": {
@@ -11915,7 +16080,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-each": {
@@ -11923,7 +16088,7 @@
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
       "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
       "requires": {
-        "any-promise": "^0.1.0"
+        "any-promise": "0.1.0"
       }
     },
     "prop-types": {
@@ -11931,8 +16096,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "proper-lockfile": {
@@ -11941,10 +16106,10 @@
       "integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
       "optional": true,
       "requires": {
-        "err-code": "^1.0.0",
-        "extend": "^3.0.0",
-        "graceful-fs": "^4.1.2",
-        "retry": "^0.10.0"
+        "err-code": "1.1.2",
+        "extend": "3.0.2",
+        "graceful-fs": "4.1.11",
+        "retry": "0.10.1"
       }
     },
     "property-information": {
@@ -11957,7 +16122,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -11976,11 +16141,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
@@ -11988,8 +16153,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -12012,8 +16177,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -12036,9 +16201,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -12058,7 +16223,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -12066,8 +16231,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -12099,7 +16264,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "setprototypeof": {
@@ -12119,10 +16284,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -12137,10 +16302,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
       "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-aria-menubutton": {
@@ -12148,9 +16313,9 @@
       "resolved": "https://registry.npmjs.org/react-aria-menubutton/-/react-aria-menubutton-5.1.1.tgz",
       "integrity": "sha512-ceBjPvuqwM2jnRFsfMlpfPdyqQ5cz4STNH7NlKpxStr2uETB/zQ2sHiIUMTuqSuOszU1kgUB2vm3aVn3xdjhcA==",
       "requires": {
-        "focus-group": "^0.3.1",
-        "prop-types": "^15.6.0",
-        "teeny-tap": "^0.2.0"
+        "focus-group": "0.3.1",
+        "prop-types": "15.6.2",
+        "teeny-tap": "0.2.0"
       }
     },
     "react-autosuggest": {
@@ -12158,9 +16323,9 @@
       "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.3.4.tgz",
       "integrity": "sha512-vcAsZw+6zkjimni4aun1tvuzVCGilmFihAgF8yCeVm/p82ssGgtQb0pnNCcEBcPzPTLJjQc2O8dLJidoOyjlcA==",
       "requires": {
-        "prop-types": "^15.5.10",
-        "react-autowhatever": "^10.1.0",
-        "shallow-equal": "^1.0.0"
+        "prop-types": "15.6.2",
+        "react-autowhatever": "10.1.2",
+        "shallow-equal": "1.0.0"
       }
     },
     "react-autowhatever": {
@@ -12168,9 +16333,9 @@
       "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.1.2.tgz",
       "integrity": "sha512-+0XgELT1LF7hHEJv5H5Zwkfb4Q1rqmMZZ5U/XJ2J+UcSPRKnG6CqEjXUJ+hYLXDHgvDqwEN5PBdxczD5rHvOuA==",
       "requires": {
-        "prop-types": "^15.5.8",
-        "react-themeable": "^1.1.0",
-        "section-iterator": "^2.0.0"
+        "prop-types": "15.6.2",
+        "react-themeable": "1.1.0",
+        "section-iterator": "2.0.0"
       }
     },
     "react-datetime": {
@@ -12178,10 +16343,10 @@
       "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.15.0.tgz",
       "integrity": "sha512-RP5OqXVfrhdoFALJzMU8tKxRFaIZzJZqZEpf5oK7pvwG80a/bET/TdJ7jT7W9lyAf1nKNo6zyYkvHW3ZJ/ypvg==",
       "requires": {
-        "create-react-class": "^15.5.2",
-        "object-assign": "^3.0.0",
-        "prop-types": "^15.5.7",
-        "react-onclickoutside": "^6.5.0"
+        "create-react-class": "15.6.3",
+        "object-assign": "3.0.0",
+        "prop-types": "15.6.2",
+        "react-onclickoutside": "6.7.1"
       },
       "dependencies": {
         "object-assign": {
@@ -12213,7 +16378,7 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.1.0",
-        "react-error-overlay": "^3.0.0",
+        "react-error-overlay": "3.0.0",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.4",
@@ -12226,8 +16391,8 @@
           "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
           "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
           "requires": {
-            "address": "^1.0.1",
-            "debug": "^2.6.0"
+            "address": "1.0.3",
+            "debug": "2.6.9"
           }
         },
         "opn": {
@@ -12235,7 +16400,7 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
           "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
           "requires": {
-            "is-wsl": "^1.1.0"
+            "is-wsl": "1.1.0"
           }
         }
       }
@@ -12245,12 +16410,12 @@
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.6.0.tgz",
       "integrity": "sha1-f6JWds+CfViokSk+PBq1naACVFo=",
       "requires": {
-        "disposables": "^1.0.1",
-        "dnd-core": "^2.6.0",
-        "hoist-non-react-statics": "^2.1.0",
-        "invariant": "^2.1.0",
-        "lodash": "^4.2.0",
-        "prop-types": "^15.5.10"
+        "disposables": "1.0.2",
+        "dnd-core": "2.6.0",
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10",
+        "prop-types": "15.6.2"
       }
     },
     "react-dnd-html5-backend": {
@@ -12258,7 +16423,7 @@
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz",
       "integrity": "sha1-WQzRzKeEQbsnTt1XH+9MCxbdz44=",
       "requires": {
-        "lodash": "^4.2.0"
+        "lodash": "4.17.10"
       }
     },
     "react-dom": {
@@ -12266,10 +16431,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-error-overlay": {
@@ -12287,10 +16452,10 @@
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
       "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
       "requires": {
-        "deep-equal": "^1.0.1",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-side-effect": "^1.1.0"
+        "deep-equal": "1.0.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "react-side-effect": "1.1.5"
       }
     },
     "react-hot-loader": {
@@ -12298,11 +16463,11 @@
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.3.tgz",
       "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
       "requires": {
-        "global": "^4.3.0",
-        "react-deep-force-update": "^2.1.1",
-        "react-proxy": "^3.0.0-alpha.0",
-        "redbox-react": "^1.3.6",
-        "source-map": "^0.6.1"
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.6.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -12332,10 +16497,10 @@
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
       "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
       "requires": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
+        "exenv": "1.2.2",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4",
+        "warning": "3.0.0"
       }
     },
     "react-onclickoutside": {
@@ -12348,7 +16513,7 @@
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-3.2.0.tgz",
       "integrity": "sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==",
       "requires": {
-        "prop-types": "^15.5.8"
+        "prop-types": "15.6.2"
       }
     },
     "react-proxy": {
@@ -12356,7 +16521,7 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.10"
       }
     },
     "react-redux": {
@@ -12364,12 +16529,12 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.9.tgz",
       "integrity": "sha512-3XS7mjTOcvaP2H5OE/LxEgDHRuEyTZxBRlwvXHzNqYkZdYd7Ra98AimWoDSHP9OcLoydjA1ocgiZxxcqeXj0Sw==",
       "requires": {
-        "create-react-class": "^15.5.1",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.5.4"
+        "create-react-class": "15.6.3",
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2"
       }
     },
     "react-router": {
@@ -12377,13 +16542,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
       "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.2",
+        "warning": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -12404,7 +16569,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
           "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.4.0"
           }
         }
       }
@@ -12414,12 +16579,12 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
       "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-router": "4.3.1",
+        "warning": "4.0.1"
       },
       "dependencies": {
         "warning": {
@@ -12427,7 +16592,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
           "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.4.0"
           }
         }
       }
@@ -12437,9 +16602,9 @@
       "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz",
       "integrity": "sha512-euSgNIANnRXr4GydIuwA7RZCefrLQzIw5WdXspS8NPYbV+FxrKSS9MKG7U9vb6vsKHONnA4VxrVNWfnMUnUQAw==",
       "requires": {
-        "history": "^4.7.2",
-        "prop-types": "^15.6.0",
-        "react-router": "^4.2.0"
+        "history": "4.7.2",
+        "prop-types": "15.6.2",
+        "react-router": "4.3.1"
       }
     },
     "react-scroll-sync": {
@@ -12452,8 +16617,8 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
       "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
       "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
+        "exenv": "1.2.2",
+        "shallowequal": "1.1.0"
       }
     },
     "react-sortable-hoc": {
@@ -12461,10 +16626,10 @@
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
       "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
       "requires": {
-        "babel-runtime": "^6.11.6",
-        "invariant": "^2.2.1",
-        "lodash": "^4.12.0",
-        "prop-types": "^15.5.7"
+        "babel-runtime": "6.26.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10",
+        "prop-types": "15.6.2"
       }
     },
     "react-split-pane": {
@@ -12472,10 +16637,10 @@
       "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.82.tgz",
       "integrity": "sha1-Qvu5/Ugj8F4DfeDas81s+b8M9Oo=",
       "requires": {
-        "inline-style-prefixer": "^3.0.6",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-style-proptype": "^3.0.0"
+        "inline-style-prefixer": "3.0.8",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4",
+        "react-style-proptype": "3.2.1"
       }
     },
     "react-style-proptype": {
@@ -12483,7 +16648,7 @@
       "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.1.tgz",
       "integrity": "sha512-Z02QsgmdZ4wYNxJsHhNGGZsIF8+MO93fYmdPaC+ljdqX3rq8tl/fSMXOGBbofGJNzq5W/2LFcONllmV6vzyYHA==",
       "requires": {
-        "prop-types": "^15.5.4"
+        "prop-types": "15.6.2"
       }
     },
     "react-textarea-autosize": {
@@ -12491,7 +16656,7 @@
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz",
       "integrity": "sha512-bx6z2I35aapr71ggw2yZIA4qhmqeTa4ZVsSaTeFvtf9kfcZppDBh2PbMt8lvbdmzEk7qbSFhAxR9vxEVm6oiMg==",
       "requires": {
-        "prop-types": "^15.6.0"
+        "prop-types": "15.6.2"
       }
     },
     "react-themeable": {
@@ -12499,7 +16664,7 @@
       "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
       "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
       "requires": {
-        "object-assign": "^3.0.0"
+        "object-assign": "3.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -12519,7 +16684,7 @@
       "resolved": "https://registry.npmjs.org/react-topbar-progress-indicator/-/react-topbar-progress-indicator-2.0.0.tgz",
       "integrity": "sha512-QEKsnwkjMvb10h7k+cFm0UeeVcRRIGhOJNqMQAbDyzSifPvlePk0KIcUb9dof2SkW7E5GaSxGsmXSpaFTYn43A==",
       "requires": {
-        "topbar": "^0.1.3"
+        "topbar": "0.1.3"
       }
     },
     "react-transition-group": {
@@ -12527,10 +16692,10 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
       "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
-        "dom-helpers": "^3.3.1",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4"
       }
     },
     "react-waypoint": {
@@ -12538,8 +16703,8 @@
       "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-7.3.4.tgz",
       "integrity": "sha1-b0oWfKccCHdXZpnWmACJ8AETf5A=",
       "requires": {
-        "consolidated-events": "^1.1.0",
-        "prop-types": "^15.0.0"
+        "consolidated-events": "1.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "read": {
@@ -12547,7 +16712,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-all-stream": {
@@ -12555,8 +16720,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.6"
       }
     },
     "read-cache": {
@@ -12564,7 +16729,7 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "requires": {
-        "pify": "^2.3.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -12584,9 +16749,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -12594,8 +16759,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -12603,7 +16768,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -12613,13 +16778,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdir-enhanced": {
@@ -12627,9 +16792,9 @@
       "resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
       "integrity": "sha1-YUYwSGkKxqRVt1ti+nioj43IXlM=",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "es6-promise": "^4.1.0",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "es6-promise": "4.2.4",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "readdirp": {
@@ -12637,10 +16802,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "rechoir": {
@@ -12648,7 +16813,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.8.1"
       }
     },
     "recursive-readdir": {
@@ -12664,7 +16829,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -12674,10 +16839,10 @@
       "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.6.0.tgz",
       "integrity": "sha512-mLjM5eYR41yOp5YKHpd3syFeGq6B4Wj5vZr64nbLvTZW5ZLff4LYk7VE4ITpVxkZpCY6OZuqh0HiP3A3uEaCpg==",
       "requires": {
-        "error-stack-parser": "^1.3.6",
-        "object-assign": "^4.0.1",
-        "prop-types": "^15.5.4",
-        "sourcemapped-stacktrace": "^1.1.6"
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "sourcemapped-stacktrace": "1.1.8"
       },
       "dependencies": {
         "error-stack-parser": {
@@ -12685,7 +16850,7 @@
           "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
           "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
           "requires": {
-            "stackframe": "^0.3.1"
+            "stackframe": "0.3.1"
           }
         },
         "stackframe": {
@@ -12700,8 +16865,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -12709,9 +16874,9 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -12726,7 +16891,7 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -12741,10 +16906,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "lodash": "4.17.10",
+        "lodash-es": "4.17.10",
+        "loose-envify": "1.4.0",
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-devtools-instrument": {
@@ -12752,8 +16917,8 @@
       "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.0.tgz",
       "integrity": "sha512-pLFQoja1ojpsSRTWbC9yyc/a+z8uwOD7FPKLp+Abs7qjsah6khA5o8HBE2wa0VipE5vniYINdkNyxV/2iWADKg==",
       "requires": {
-        "lodash": "^4.2.0",
-        "symbol-observable": "^1.0.2"
+        "lodash": "4.17.10",
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-notifications": {
@@ -12761,10 +16926,10 @@
       "resolved": "https://registry.npmjs.org/redux-notifications/-/redux-notifications-4.0.1.tgz",
       "integrity": "sha512-mRVaEcsvu5B4P8x8kW0uY83EQqaWL/0+/NvL4bdbHGJVg+Rwx54MgBU1s+tB6RAA2E6NX/DmQrO4EbFDcQSi+w==",
       "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.10",
-        "react-redux": "^4.0.0",
-        "react-transition-group": "^1.1.3"
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "react-redux": "4.4.9",
+        "react-transition-group": "1.2.1"
       },
       "dependencies": {
         "react-transition-group": {
@@ -12772,11 +16937,11 @@
           "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
           "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
           "requires": {
-            "chain-function": "^1.0.0",
-            "dom-helpers": "^3.2.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.5.6",
-            "warning": "^3.0.0"
+            "chain-function": "1.0.1",
+            "dom-helpers": "3.3.1",
+            "loose-envify": "1.4.0",
+            "prop-types": "15.6.2",
+            "warning": "3.0.0"
           }
         }
       }
@@ -12806,9 +16971,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -12816,7 +16981,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -12824,8 +16989,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -12833,9 +16998,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -12843,8 +17008,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -12852,7 +17017,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -12865,7 +17030,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12880,14 +17045,14 @@
       "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-2.0.3.tgz",
       "integrity": "sha512-KzOH3F92J7Wvr3WuaqSO69FuN+vwbitVYxdSolLXrwLwdo67VXn/qSYGR7gnYDJKgfm/+m3l8hZHY43Zg+YscQ==",
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "hast-util-embedded": "^1.0.0",
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-body-ok-link": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "html-whitespace-sensitive-tag-names": "^1.0.0",
-        "unist-util-is": "^2.0.0",
-        "unist-util-modify-children": "^1.0.0"
+        "collapse-white-space": "1.0.4",
+        "hast-util-embedded": "1.0.1",
+        "hast-util-has-property": "1.0.1",
+        "hast-util-is-body-ok-link": "1.0.1",
+        "hast-util-is-element": "1.0.1",
+        "html-whitespace-sensitive-tag-names": "1.0.0",
+        "unist-util-is": "2.1.2",
+        "unist-util-modify-children": "1.1.2"
       }
     },
     "rehype-parse": {
@@ -12895,9 +17060,9 @@
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-3.1.0.tgz",
       "integrity": "sha1-f1InpZej85/EuThkYWFTnERO5yg=",
       "requires": {
-        "hast-util-from-parse5": "^1.0.0",
-        "parse5": "^2.1.5",
-        "xtend": "^4.0.1"
+        "hast-util-from-parse5": "1.1.0",
+        "parse5": "2.2.3",
+        "xtend": "4.0.1"
       }
     },
     "rehype-remark": {
@@ -12905,7 +17070,7 @@
       "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-2.1.0.tgz",
       "integrity": "sha1-hMrdQUENI96Pg+FB6SNCwt+Uwcg=",
       "requires": {
-        "hast-util-to-mdast": "^1.1.0"
+        "hast-util-to-mdast": "1.2.0"
       }
     },
     "rehype-stringify": {
@@ -12913,8 +17078,8 @@
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-3.0.0.tgz",
       "integrity": "sha1-n+8IaCE8Lc4veAt289BIjIXoGes=",
       "requires": {
-        "hast-util-to-html": "^3.0.0",
-        "xtend": "^4.0.1"
+        "hast-util-to-html": "3.1.0",
+        "xtend": "4.0.1"
       }
     },
     "relateurl": {
@@ -12927,22 +17092,22 @@
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.4.1.tgz",
       "integrity": "sha512-8O9dVIOOTp1TlbQhdNp2EBO/WUaSEPaYhQ8HFgMVjpvLTCaCfHEpptNQPJf5uDG/AH1p2qhPtLaCyQ2pBYh7Cw==",
       "requires": {
-        "babel-generator": "^6.24.1",
-        "babel-polyfill": "^6.20.0",
-        "babel-preset-fbjs": "^2.1.4",
-        "babel-runtime": "^6.23.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.24.1",
-        "babylon": "^6.18.0",
-        "chalk": "^1.1.1",
-        "fast-glob": "^1.0.1",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^0.8.14",
-        "graphql": "^0.11.3",
-        "immutable": "~3.7.6",
+        "babel-generator": "6.26.1",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-fbjs": "2.2.0",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "chalk": "1.1.3",
+        "fast-glob": "1.0.1",
+        "fb-watchman": "2.0.0",
+        "fbjs": "0.8.17",
+        "graphql": "0.11.7",
+        "immutable": "3.7.6",
         "relay-runtime": "1.4.1",
-        "signedsource": "^1.0.0",
-        "yargs": "^9.0.0"
+        "signedsource": "1.0.0",
+        "yargs": "9.0.1"
       },
       "dependencies": {
         "cliui": {
@@ -12950,9 +17115,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -12960,9 +17125,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -12972,7 +17137,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "yargs": {
@@ -12980,19 +17145,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         },
         "yargs-parser": {
@@ -13000,7 +17165,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -13015,8 +17180,8 @@
       "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.4.1.tgz",
       "integrity": "sha512-hsEVCPik0Wo+8xvVqaMK96d45fqYAcHz/UCAw2qy1dxY+2kHUhnDUh6CGilFKB1H3f+DLzvqIHUyNYKWS/jZ/g==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "fbjs": "^0.8.14",
+        "babel-runtime": "6.26.0",
+        "fbjs": "0.8.17",
         "relay-debugger-react-native-runtime": "0.0.10"
       }
     },
@@ -13025,9 +17190,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-7.0.1.tgz",
       "integrity": "sha1-pd5NrPq/D2CkmCbvJMR5gH+QS/s=",
       "requires": {
-        "remark-parse": "^3.0.0",
-        "remark-stringify": "^3.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "3.0.1",
+        "remark-stringify": "3.0.1",
+        "unified": "6.2.0"
       }
     },
     "remark-parse": {
@@ -13035,22 +17200,22 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
       "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "has": "^1.0.1",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.4",
+        "has": "1.0.3",
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "is-word-character": "1.0.2",
+        "markdown-escapes": "1.0.2",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.1",
+        "unherit": "1.1.1",
+        "unist-util-remove-position": "1.1.2",
+        "vfile-location": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "remark-rehype": {
@@ -13058,7 +17223,7 @@
       "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-2.0.1.tgz",
       "integrity": "sha1-E+mJ+J7hVES9I1Tf/XZ9qSK5heM=",
       "requires": {
-        "mdast-util-to-hast": "^2.2.0"
+        "mdast-util-to-hast": "2.5.0"
       }
     },
     "remark-retext": {
@@ -13066,7 +17231,7 @@
       "resolved": "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.0.tgz",
       "integrity": "sha1-Gz3y1JRpwNNZbK2G6RUDqLYA/cw=",
       "requires": {
-        "mdast-util-to-nlcst": "^3.2.0"
+        "mdast-util-to-nlcst": "3.2.0"
       }
     },
     "remark-stringify": {
@@ -13074,20 +17239,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
       "integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.2",
+        "markdown-table": "1.1.2",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
+        "stringify-entities": "1.3.2",
+        "unherit": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "remote-redux-devtools": {
@@ -13095,12 +17260,12 @@
       "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz",
       "integrity": "sha1-QsuV36nlTB2WcTF8Xnu6QeaMrsI=",
       "requires": {
-        "jsan": "^3.1.5",
-        "querystring": "^0.2.0",
-        "redux-devtools-instrument": "^1.3.3",
-        "remotedev-utils": "^0.1.1",
-        "rn-host-detect": "^1.0.1",
-        "socketcluster-client": "^5.3.1"
+        "jsan": "3.1.10",
+        "querystring": "0.2.0",
+        "redux-devtools-instrument": "1.9.0",
+        "remotedev-utils": "0.1.4",
+        "rn-host-detect": "1.1.4",
+        "socketcluster-client": "5.5.2"
       }
     },
     "remotedev-serialize": {
@@ -13108,7 +17273,7 @@
       "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz",
       "integrity": "sha1-D1mAALfddRXWf5tRph0hHhjOlVQ=",
       "requires": {
-        "jsan": "^3.1.9"
+        "jsan": "3.1.10"
       }
     },
     "remotedev-utils": {
@@ -13116,11 +17281,11 @@
       "resolved": "https://registry.npmjs.org/remotedev-utils/-/remotedev-utils-0.1.4.tgz",
       "integrity": "sha1-ZDcAgZqUNngHPHXrGF6B2WYgs0g=",
       "requires": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.5",
-        "lodash": "^4.0.0",
-        "remotedev-serialize": "^0.1.0",
-        "shortid": "^2.2.6"
+        "get-params": "0.1.2",
+        "jsan": "3.1.10",
+        "lodash": "4.17.10",
+        "remotedev-serialize": "0.1.1",
+        "shortid": "2.2.12"
       }
     },
     "remove-trailing-separator": {
@@ -13133,11 +17298,11 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.1",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "~0.3"
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -13162,7 +17327,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -13175,26 +17340,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-directory": {
@@ -13222,7 +17387,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -13230,7 +17395,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -13238,8 +17403,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -13247,7 +17412,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -13272,8 +17437,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -13286,8 +17451,8 @@
       "resolved": "https://registry.npmjs.org/retext-english/-/retext-english-3.0.0.tgz",
       "integrity": "sha1-wXy1a9Xxuj3uM1XdurefHEiUqAk=",
       "requires": {
-        "parse-english": "^4.0.0",
-        "unherit": "^1.0.4"
+        "parse-english": "4.1.1",
+        "unherit": "1.1.1"
       }
     },
     "retry": {
@@ -13316,7 +17481,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -13324,7 +17489,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -13332,8 +17497,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rn-host-detect": {
@@ -13348,7 +17513,7 @@
       "optional": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "*"
+        "@types/node": "7.0.68"
       }
     },
     "rsvp": {
@@ -13361,7 +17526,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -13374,7 +17539,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -13387,7 +17552,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -13401,13 +17566,13 @@
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
       "optional": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "minimatch": "^3.0.2",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.10.0"
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.2",
+        "fb-watchman": "2.0.0",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
       },
       "dependencies": {
         "minimist": {
@@ -13423,7 +17588,7 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
       "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
       "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
+        "truncate-utf8-bytes": "1.0.2"
       }
     },
     "sanitize-html": {
@@ -13431,16 +17596,16 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.4.tgz",
       "integrity": "sha512-hjyDYCYrQuhnEjq+5lenLlIfdPBtnZ7z0DkQOC8YGxvkuOInH+1SrkNTj30t4f2/SSv9c5kLniB+uCIpBvYuew==",
       "requires": {
-        "chalk": "^2.3.0",
-        "htmlparser2": "^3.9.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.0",
-        "postcss": "^6.0.14",
-        "srcset": "^1.0.0",
-        "xtend": "^4.0.0"
+        "chalk": "2.4.1",
+        "htmlparser2": "3.9.2",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.escaperegexp": "4.1.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.mergewith": "4.6.1",
+        "postcss": "6.0.23",
+        "srcset": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13448,7 +17613,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -13456,9 +17621,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "domhandler": {
@@ -13466,7 +17631,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "has-flag": {
@@ -13479,12 +17644,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "postcss": {
@@ -13492,9 +17657,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -13507,7 +17672,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13517,10 +17682,10 @@
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13533,9 +17698,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -13543,7 +17708,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "load-json-file": {
@@ -13551,11 +17716,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "os-locale": {
@@ -13563,7 +17728,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "path-type": {
@@ -13571,9 +17736,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -13586,9 +17751,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -13596,8 +17761,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "string-width": {
@@ -13605,9 +17770,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -13615,7 +17780,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "which-module": {
@@ -13628,19 +17793,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -13648,7 +17813,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -13658,9 +17823,9 @@
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-4.1.1.tgz",
       "integrity": "sha1-ee+UaM8L9kbClSnh8sumvW5Rx7w=",
       "requires": {
-        "async": "^2.0.1",
-        "loader-utils": "^0.2.15",
-        "object-assign": "^4.1.0"
+        "async": "2.6.1",
+        "loader-utils": "0.2.17",
+        "object-assign": "4.1.1"
       }
     },
     "sax": {
@@ -13673,7 +17838,7 @@
       "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.0.6.tgz",
       "integrity": "sha1-s4vUepk+eCkPvFNGeGf2sqCghjk=",
       "requires": {
-        "sc-emitter": "1.x.x"
+        "sc-emitter": "1.1.0"
       }
     },
     "sc-emitter": {
@@ -13706,7 +17871,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "^5.0.0"
+        "ajv": "5.5.2"
       }
     },
     "scroll-behavior": {
@@ -13714,8 +17879,8 @@
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.9.tgz",
       "integrity": "sha1-6/4GWEVbgq2IW2YZUhVBZnTazOI=",
       "requires": {
-        "dom-helpers": "^3.2.1",
-        "invariant": "^2.2.2"
+        "dom-helpers": "3.3.1",
+        "invariant": "2.2.4"
       }
     },
     "scss-tokenizer": {
@@ -13723,8 +17888,8 @@
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
+        "js-base64": "2.4.8",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -13732,7 +17897,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -13747,7 +17912,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -13755,7 +17920,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -13780,7 +17945,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "semver-regex": {
@@ -13793,7 +17958,7 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -13802,18 +17967,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -13843,10 +18008,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-styles": {
@@ -13854,7 +18019,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -13862,9 +18027,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "fast-deep-equal": {
@@ -13887,7 +18052,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13917,7 +18082,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "~1.33.0"
+            "mime-db": "1.33.0"
           }
         },
         "path-to-regexp": {
@@ -13932,13 +18097,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.19",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -13946,9 +18111,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -13967,10 +18132,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13978,7 +18143,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -13998,8 +18163,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shallow-compare": {
@@ -14022,16 +18187,16 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.5.tgz",
       "integrity": "sha512-ZgSX4EAmJzqcykEGZZtth1YHeb21LH4IRnFYtqvvx49ix3R7jxBbXJSrjXrCsVfyE1woaZR/JdsQCLLGs3cF6w==",
       "requires": {
-        "color": "^3.0.0",
-        "detect-libc": "^1.0.3",
-        "fs-copy-file-sync": "^1.1.1",
-        "nan": "^2.10.0",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^4.0.0",
-        "semver": "^5.5.0",
-        "simple-get": "^2.8.1",
-        "tar": "^4.4.4",
-        "tunnel-agent": "^0.6.0"
+        "color": "3.0.0",
+        "detect-libc": "1.0.3",
+        "fs-copy-file-sync": "1.1.1",
+        "nan": "2.10.0",
+        "npmlog": "4.1.2",
+        "prebuild-install": "4.0.0",
+        "semver": "5.5.0",
+        "simple-get": "2.8.1",
+        "tar": "4.4.6",
+        "tunnel-agent": "0.6.0"
       },
       "dependencies": {
         "color": {
@@ -14039,8 +18204,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
           "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
+            "color-convert": "1.9.2",
+            "color-string": "1.5.3"
           }
         },
         "color-string": {
@@ -14048,8 +18213,8 @@
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.1",
+            "simple-swizzle": "0.2.2"
           }
         },
         "gauge": {
@@ -14057,14 +18222,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -14072,7 +18237,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "npmlog": {
@@ -14080,10 +18245,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "string-width": {
@@ -14091,9 +18256,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "tar": {
@@ -14101,13 +18266,13 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
           "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.3",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           }
         },
         "yallist": {
@@ -14122,7 +18287,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -14135,10 +18300,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "shelljs": {
@@ -14146,9 +18311,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.0.tgz",
       "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=",
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       },
       "dependencies": {
         "interpret": {
@@ -14163,7 +18328,7 @@
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.12.tgz",
       "integrity": "sha512-sw0knB/ioTu/jVYgJz1IP1b5uhPZtZYwQ9ir/EqXZHI4+Jh8rzzGLM3LKptGHBKoDsgTBDfr4yCRNUX7hEIksQ==",
       "requires": {
-        "nanoid": "^1.0.7"
+        "nanoid": "1.1.0"
       }
     },
     "sift": {
@@ -14191,9 +18356,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "simple-swizzle": {
@@ -14201,7 +18366,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.2"
       },
       "dependencies": {
         "is-arrayish": {
@@ -14221,14 +18386,14 @@
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.30.7.tgz",
       "integrity": "sha512-pETHjdOXB4IVukjw56eKjFACwio6V1SBu3lK+kb3Jvg0qc9Uy1bikG2Nd7STpE29v8x1HbQ56Ys+g6Ois9yQMA==",
       "requires": {
-        "debug": "^2.3.2",
-        "direction": "^0.1.5",
-        "esrever": "^0.2.0",
-        "is-empty": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "lodash": "^4.17.4",
-        "slate-dev-logger": "^0.1.33",
-        "type-of": "^2.0.1"
+        "debug": "2.6.9",
+        "direction": "0.1.5",
+        "esrever": "0.2.0",
+        "is-empty": "1.2.0",
+        "is-plain-object": "2.0.4",
+        "lodash": "4.17.10",
+        "slate-dev-logger": "0.1.42",
+        "type-of": "2.0.1"
       }
     },
     "slate-base64-serializer": {
@@ -14236,7 +18401,7 @@
       "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.45.tgz",
       "integrity": "sha1-pMX15Zs2gcscqsJkHGiRpUK1mbQ=",
       "requires": {
-        "isomorphic-base64": "^1.0.2"
+        "isomorphic-base64": "1.0.2"
       }
     },
     "slate-dev-logger": {
@@ -14259,7 +18424,7 @@
       "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.4.16.tgz",
       "integrity": "sha512-eiXUaes5jhZ/T4RCXKcO8nJ6cOc//Mg9eE/xJeaeq6afM/mEq4nd4EGHnPvWy2Ue8jgePDXK1OTg41aTmuy6vQ==",
       "requires": {
-        "slate-dev-logger": "^0.1.36"
+        "slate-dev-logger": "0.1.42"
       }
     },
     "slate-prop-types": {
@@ -14267,7 +18432,7 @@
       "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.4.43.tgz",
       "integrity": "sha1-0j511ZjZEh7bvV5mXQ3L7d7UX+4=",
       "requires": {
-        "slate-dev-logger": "^0.1.42"
+        "slate-dev-logger": "0.1.42"
       }
     },
     "slate-react": {
@@ -14275,20 +18440,20 @@
       "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.10.11.tgz",
       "integrity": "sha512-rwcysp/WkSuoNds2paHV+adqpPS3iZ2nY4X+uxDh8wCXkgCY3fYmLpvOcOmVS0FJHIfF3PR8PZ6UWoSHRI9tAA==",
       "requires": {
-        "debug": "^2.3.2",
-        "get-window": "^1.1.1",
-        "is-hotkey": "^0.1.1",
-        "is-in-browser": "^1.1.3",
-        "is-window": "^1.0.2",
-        "keycode": "^2.1.2",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "react-portal": "^3.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.8",
-        "slate-dev-logger": "^0.1.32",
-        "slate-plain-serializer": "^0.4.6",
-        "slate-prop-types": "^0.4.6"
+        "debug": "2.6.9",
+        "get-window": "1.1.2",
+        "is-hotkey": "0.1.2",
+        "is-in-browser": "1.1.3",
+        "is-window": "1.0.2",
+        "keycode": "2.2.0",
+        "prop-types": "15.6.2",
+        "react-immutable-proptypes": "2.1.0",
+        "react-portal": "3.2.0",
+        "selection-is-backward": "1.0.0",
+        "slate-base64-serializer": "0.2.45",
+        "slate-dev-logger": "0.1.42",
+        "slate-plain-serializer": "0.4.16",
+        "slate-prop-types": "0.4.43"
       }
     },
     "slate-soft-break": {
@@ -14301,14 +18466,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -14316,7 +18481,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -14324,7 +18489,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -14334,9 +18499,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -14344,7 +18509,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -14352,7 +18517,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -14360,7 +18525,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -14368,9 +18533,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -14390,7 +18555,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -14398,7 +18563,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       },
       "dependencies": {
         "hoek": {
@@ -14413,12 +18578,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -14445,15 +18610,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -14473,7 +18638,7 @@
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -14501,10 +18666,10 @@
         "clone": "2.1.1",
         "linked-list": "0.1.0",
         "querystring": "0.2.0",
-        "sc-channel": "~1.0.6",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "sc-formatter": "~3.0.0",
+        "sc-channel": "1.0.6",
+        "sc-emitter": "1.1.0",
+        "sc-errors": "1.3.3",
+        "sc-formatter": "3.0.2",
         "ws": "3.0.0"
       },
       "dependencies": {
@@ -14520,8 +18685,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "faye-websocket": {
@@ -14529,7 +18694,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -14539,12 +18704,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.3"
       }
     },
     "sort-keys": {
@@ -14552,7 +18717,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-list-map": {
@@ -14570,11 +18735,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -14582,7 +18747,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -14623,8 +18788,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -14637,8 +18802,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -14651,7 +18816,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -14664,9 +18829,9 @@
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       }
     },
     "srcset": {
@@ -14674,8 +18839,8 @@
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
-        "array-uniq": "^1.0.2",
-        "number-is-nan": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "number-is-nan": "1.0.1"
       }
     },
     "sshpk": {
@@ -14683,15 +18848,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
@@ -14719,8 +18884,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -14728,7 +18893,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -14738,11 +18903,11 @@
       "resolved": "https://registry.npmjs.org/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-3.4.1.tgz",
       "integrity": "sha1-buIkaIMLxUZ5ijfg/Kb9aZzJO4E=",
       "requires": {
-        "bluebird": "^3.0.5",
-        "cheerio": "^0.22.0",
-        "eval": "^0.1.0",
-        "url": "^0.11.0",
-        "webpack-sources": "^0.2.0"
+        "bluebird": "3.5.1",
+        "cheerio": "0.22.0",
+        "eval": "0.1.2",
+        "url": "0.11.0",
+        "webpack-sources": "0.2.3"
       },
       "dependencies": {
         "source-list-map": {
@@ -14755,8 +18920,8 @@
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
           "requires": {
-            "source-list-map": "^1.1.1",
-            "source-map": "~0.5.3"
+            "source-list-map": "1.1.2",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -14771,7 +18936,7 @@
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "steno": {
@@ -14779,7 +18944,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
       "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "graceful-fs": "^4.1.3"
+        "graceful-fs": "4.1.11"
       }
     },
     "stream-browserify": {
@@ -14787,8 +18952,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-cache": {
@@ -14801,8 +18966,8 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-http": {
@@ -14810,11 +18975,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-parser": {
@@ -14822,7 +18987,7 @@
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
       "requires": {
-        "debug": "2"
+        "debug": "2.6.9"
       }
     },
     "stream-shift": {
@@ -14840,7 +19005,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "requires": {
-        "stream-to": "~0.2.0"
+        "stream-to": "0.2.2"
       }
     },
     "strict-uri-encode": {
@@ -14853,7 +19018,7 @@
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-1.2.0.tgz",
       "integrity": "sha1-11FTyzg4RjGLejmo2SkrtNtOnDA=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.10"
       }
     },
     "string-width": {
@@ -14861,8 +19026,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14875,7 +19040,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -14885,7 +19050,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-entities": {
@@ -14893,10 +19058,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "stringstream": {
@@ -14909,7 +19074,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -14922,8 +19087,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -14931,7 +19096,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -14946,12 +19111,12 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "requires": {
-        "chalk": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "is-absolute": "^0.1.5",
-        "is-natural-number": "^2.0.0",
-        "minimist": "^1.1.0",
-        "sum-up": "^1.0.1"
+        "chalk": "1.1.3",
+        "get-stdin": "4.0.1",
+        "is-absolute": "0.1.7",
+        "is-natural-number": "2.1.1",
+        "minimist": "1.2.0",
+        "sum-up": "1.0.3"
       },
       "dependencies": {
         "is-absolute": {
@@ -14959,7 +19124,7 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "requires": {
-            "is-relative": "^0.1.0"
+            "is-relative": "0.1.3"
           }
         },
         "is-relative": {
@@ -14984,7 +19149,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -14997,7 +19162,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "style-loader": {
@@ -15005,7 +19170,7 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
       "requires": {
-        "loader-utils": "^1.0.2"
+        "loader-utils": "1.1.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -15013,9 +19178,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -15025,7 +19190,7 @@
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -15038,13 +19203,13 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
       }
     },
     "symbol": {
@@ -15069,23 +19234,23 @@
       "integrity": "sha512-ual5RmcBt7yeXrmpEQIHmITZpNIf289hCTixo/gSOQpdVLLC5v7/W//qn3ZgK6YNdUBptS4szaGVrh7LxOqSHg==",
       "optional": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-amd-system-wrapper": "^0.3.7",
-        "babel-plugin-transform-cjs-system-wrapper": "^0.6.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.6.5",
-        "babel-plugin-transform-global-system-wrapper": "^0.3.4",
-        "babel-plugin-transform-system-register": "^0.0.1",
-        "bluebird": "^3.3.4",
+        "babel-core": "6.26.3",
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-amd-system-wrapper": "0.3.7",
+        "babel-plugin-transform-cjs-system-wrapper": "0.6.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-global-system-wrapper": "0.3.4",
+        "babel-plugin-transform-system-register": "0.0.1",
+        "bluebird": "3.5.1",
         "data-uri-to-buffer": "0.0.4",
-        "es6-template-strings": "^2.0.0",
-        "glob": "^7.0.3",
-        "mkdirp": "^0.5.1",
-        "rollup": "^0.58.2",
-        "source-map": "^0.5.3",
-        "systemjs": "^0.19.46",
+        "es6-template-strings": "2.0.1",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "rollup": "0.58.2",
+        "source-map": "0.5.7",
+        "systemjs": "0.19.47",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "systemjs": {
@@ -15094,7 +19259,7 @@
           "integrity": "sha1-yMk5NxgPP1SBx2nNJyB2P7SjHG8=",
           "optional": true,
           "requires": {
-            "when": "^3.7.5"
+            "when": "3.7.8"
           }
         }
       }
@@ -15109,9 +19274,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "tar-fs": {
@@ -15119,10 +19284,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.1"
       }
     },
     "tar-stream": {
@@ -15130,13 +19295,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "teeny-tap": {
@@ -15154,8 +19319,8 @@
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "requires": {
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "temp-dir": "1.0.0",
+        "uuid": "3.3.2"
       }
     },
     "term-size": {
@@ -15163,7 +19328,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       },
       "dependencies": {
         "execa": {
@@ -15171,13 +19336,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -15197,8 +19362,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -15206,8 +19371,8 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -15225,7 +19390,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tinycolor2": {
@@ -15238,7 +19403,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -15252,7 +19417,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -15260,7 +19425,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -15290,7 +19455,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -15298,10 +19463,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -15309,8 +19474,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -15318,7 +19483,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -15343,7 +19508,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "toposort": {
@@ -15356,7 +19521,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -15371,7 +19536,7 @@
       "resolved": "https://registry.npmjs.org/toxic/-/toxic-1.0.1.tgz",
       "integrity": "sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "traceur": {
@@ -15379,11 +19544,11 @@
       "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.105.tgz",
       "integrity": "sha1-XPne6D1rd4YcPWxE1ThZrterBHk=",
       "requires": {
-        "commander": "2.9.x",
-        "glob": "5.0.x",
-        "rsvp": "^3.0.13",
-        "semver": "^4.3.3",
-        "source-map-support": "~0.2.8"
+        "commander": "2.9.0",
+        "glob": "5.0.15",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6",
+        "source-map-support": "0.2.10"
       },
       "dependencies": {
         "glob": {
@@ -15391,11 +19556,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "semver": {
@@ -15408,7 +19573,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "source-map-support": {
@@ -15441,7 +19606,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right": {
@@ -15464,7 +19629,7 @@
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "requires": {
-        "glob": "^6.0.4"
+        "glob": "6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -15472,11 +19637,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -15486,7 +19651,7 @@
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "requires": {
-        "utf8-byte-length": "^1.0.1"
+        "utf8-byte-length": "1.0.4"
       }
     },
     "tslib": {
@@ -15504,7 +19669,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -15519,7 +19684,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.19"
       }
     },
     "type-of": {
@@ -15542,9 +19707,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -15557,8 +19722,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -15567,9 +19732,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -15595,8 +19760,8 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "unherit": {
@@ -15604,8 +19769,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -15613,12 +19778,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-string": "^0.1.0"
+        "bail": "1.0.3",
+        "extend": "3.0.2",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.2",
+        "vfile": "2.3.0",
+        "x-is-string": "0.1.0"
       }
     },
     "union-value": {
@@ -15626,10 +19791,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -15637,7 +19802,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -15645,10 +19810,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -15668,8 +19833,8 @@
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
       }
     },
     "unique-string": {
@@ -15677,7 +19842,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-builder": {
@@ -15685,7 +19850,7 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
       "integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
       "requires": {
-        "object-assign": "^4.1.0"
+        "object-assign": "4.1.1"
       }
     },
     "unist-util-generated": {
@@ -15703,7 +19868,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "^1.0.0"
+        "array-iterate": "1.1.2"
       }
     },
     "unist-util-position": {
@@ -15716,7 +19881,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.4.0"
       }
     },
     "unist-util-select": {
@@ -15724,9 +19889,9 @@
       "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
       "integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
       "requires": {
-        "css-selector-parser": "^1.1.0",
-        "debug": "^2.2.0",
-        "nth-check": "^1.0.1"
+        "css-selector-parser": "1.3.0",
+        "debug": "2.6.9",
+        "nth-check": "1.0.1"
       }
     },
     "unist-util-stringify-position": {
@@ -15739,7 +19904,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
       "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "unist-util-visit-parents": "2.0.1"
       },
       "dependencies": {
         "unist-util-visit-parents": {
@@ -15747,7 +19912,7 @@
           "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
           "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
           "requires": {
-            "unist-util-is": "^2.1.2"
+            "unist-util-is": "2.1.2"
           }
         }
       }
@@ -15767,8 +19932,8 @@
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
       "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
       "requires": {
-        "isnumeric": "^0.2.0",
-        "viewport-dimensions": "^0.2.0"
+        "isnumeric": "0.2.0",
+        "viewport-dimensions": "0.2.0"
       }
     },
     "universalify": {
@@ -15786,8 +19951,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -15795,9 +19960,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -15841,16 +20006,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15858,7 +20023,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -15866,9 +20031,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -15881,7 +20046,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15896,7 +20061,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -15925,9 +20090,9 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "requires": {
-        "loader-utils": "^1.0.2",
-        "mime": "^1.4.1",
-        "schema-utils": "^0.3.0"
+        "loader-utils": "1.1.0",
+        "mime": "1.6.0",
+        "schema-utils": "0.3.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -15935,9 +20100,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -15947,8 +20112,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "url-parse-lax": {
@@ -15956,7 +20121,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -15964,7 +20129,7 @@
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "url-to-options": {
@@ -16025,7 +20190,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "vali-date": {
@@ -16043,8 +20208,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-equal": {
@@ -16067,9 +20232,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -16077,10 +20242,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "1.1.6",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-message": "1.0.1"
       }
     },
     "vfile-location": {
@@ -16093,7 +20258,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.2"
       }
     },
     "viewport-dimensions": {
@@ -16106,8 +20271,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -16123,8 +20288,8 @@
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.0"
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "vinyl-fs": {
@@ -16132,23 +20297,23 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
-        "duplexify": "^3.2.0",
-        "glob-stream": "^5.3.2",
-        "graceful-fs": "^4.0.0",
+        "duplexify": "3.6.0",
+        "glob-stream": "5.3.5",
+        "graceful-fs": "4.1.11",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "^0.3.0",
-        "lazystream": "^1.0.0",
-        "lodash.isequal": "^4.0.0",
-        "merge-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.0",
-        "readable-stream": "^2.0.4",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^1.0.0",
-        "through2": "^2.0.0",
-        "through2-filter": "^2.0.0",
-        "vali-date": "^1.0.0",
-        "vinyl": "^1.0.0"
+        "is-valid-glob": "0.3.0",
+        "lazystream": "1.0.0",
+        "lodash.isequal": "4.5.0",
+        "merge-stream": "1.0.1",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "1.0.0",
+        "through2": "2.0.3",
+        "through2-filter": "2.0.0",
+        "vali-date": "1.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -16156,7 +20321,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -16175,7 +20340,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "optional": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "ware": {
@@ -16183,7 +20348,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "warning": {
@@ -16191,7 +20356,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "watch": {
@@ -16205,9 +20370,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "requires": {
-        "async": "^0.9.0",
-        "chokidar": "^1.0.0",
-        "graceful-fs": "^4.1.2"
+        "async": "0.9.2",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "async": {
@@ -16227,21 +20392,21 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "requires": {
-        "acorn": "^3.0.0",
-        "async": "^1.3.0",
-        "clone": "^1.0.2",
-        "enhanced-resolve": "~0.9.0",
-        "interpret": "^0.6.4",
-        "loader-utils": "^0.2.11",
-        "memory-fs": "~0.3.0",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^0.7.0",
-        "optimist": "~0.6.0",
-        "supports-color": "^3.1.0",
-        "tapable": "~0.1.8",
-        "uglify-js": "~2.7.3",
-        "watchpack": "^0.2.1",
-        "webpack-core": "~0.6.9"
+        "acorn": "3.3.0",
+        "async": "1.5.2",
+        "clone": "1.0.4",
+        "enhanced-resolve": "0.9.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.7.0",
+        "optimist": "0.6.1",
+        "supports-color": "3.2.3",
+        "tapable": "0.1.10",
+        "uglify-js": "2.7.5",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.9"
       },
       "dependencies": {
         "async": {
@@ -16254,7 +20419,7 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
           "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
           "requires": {
-            "inherits": "^2.0.1"
+            "inherits": "2.0.3"
           }
         },
         "browserify-zlib": {
@@ -16262,7 +20427,7 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "~0.2.0"
+            "pako": "0.2.9"
           }
         },
         "camelcase": {
@@ -16275,8 +20440,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -16301,28 +20466,28 @@
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
           "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
           "requires": {
-            "assert": "^1.1.1",
-            "browserify-zlib": "^0.1.4",
-            "buffer": "^4.9.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "^1.0.0",
+            "assert": "1.4.1",
+            "browserify-zlib": "0.1.4",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
             "crypto-browserify": "3.3.0",
-            "domain-browser": "^1.1.1",
-            "events": "^1.0.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
             "https-browserify": "0.0.1",
-            "os-browserify": "^0.2.0",
+            "os-browserify": "0.2.1",
             "path-browserify": "0.0.0",
-            "process": "^0.11.0",
-            "punycode": "^1.2.4",
-            "querystring-es3": "^0.2.0",
-            "readable-stream": "^2.0.5",
-            "stream-browserify": "^2.0.1",
-            "stream-http": "^2.3.1",
-            "string_decoder": "^0.10.25",
-            "timers-browserify": "^2.0.2",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.6",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.3",
+            "string_decoder": "0.10.31",
+            "timers-browserify": "2.0.10",
             "tty-browserify": "0.0.0",
-            "url": "^0.11.0",
-            "util": "^0.10.3",
+            "url": "0.11.0",
+            "util": "0.10.4",
             "vm-browserify": "0.0.4"
           }
         },
@@ -16361,7 +20526,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "uglify-js": {
@@ -16369,10 +20534,10 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "async": {
@@ -16387,8 +20552,8 @@
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
           "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
           "requires": {
-            "source-list-map": "~0.1.7",
-            "source-map": "~0.4.1"
+            "source-list-map": "0.1.8",
+            "source-map": "0.4.4"
           },
           "dependencies": {
             "source-map": {
@@ -16396,7 +20561,7 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -16406,9 +20571,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -16419,13 +20584,13 @@
       "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-1.0.0.tgz",
       "integrity": "sha1-VKG8QDbi7tKzzh/Wp+McCb6ZU4o=",
       "requires": {
-        "chalk": "^2.0",
-        "lodash.get": "^4.0",
-        "lodash.has": "^4.0",
-        "lodash.keys": "^4.0",
-        "lodash.merge": "^4.0",
-        "lodash.pick": "^4.0",
-        "mkdirp": "^0.5"
+        "chalk": "2.4.1",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.keys": "4.2.0",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -16433,7 +20598,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "chalk": {
@@ -16441,9 +20606,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -16456,7 +20621,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16481,7 +20646,7 @@
       "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
       "integrity": "sha1-B/xVq6gdF9uoyuWkPWvWkjb4tfg=",
       "requires": {
-        "source-map": "~0.1.38"
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "source-map": {
@@ -16489,7 +20654,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -16499,11 +20664,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.1"
       },
       "dependencies": {
         "memory-fs": {
@@ -16511,8 +20676,8 @@
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -16522,19 +20687,19 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
       "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
       "requires": {
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "express": "^4.13.3",
-        "http-proxy-middleware": "~0.17.1",
+        "compression": "1.7.3",
+        "connect-history-api-fallback": "1.5.0",
+        "express": "4.16.3",
+        "http-proxy-middleware": "0.17.4",
         "open": "0.0.5",
-        "optimist": "~0.6.1",
-        "serve-index": "^1.7.2",
-        "sockjs": "^0.3.15",
-        "sockjs-client": "^1.0.3",
-        "stream-cache": "~0.0.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^3.1.1",
-        "webpack-dev-middleware": "^1.10.2"
+        "optimist": "0.6.1",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "stream-cache": "0.0.2",
+        "strip-ansi": "3.0.1",
+        "supports-color": "3.2.3",
+        "webpack-dev-middleware": "1.12.2"
       },
       "dependencies": {
         "supports-color": {
@@ -16542,7 +20707,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -16553,9 +20718,9 @@
       "integrity": "sha512-mrG3bJGX4jgWbrpY0ghIpPgCmNhZziFMBJBmZfpIe6K/P1rWPkdkbGihbCUIufgQ8ruX4txE5/CKSeFNzDcYOw==",
       "requires": {
         "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
-        "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "webpack-md5-hash": {
@@ -16563,7 +20728,7 @@
       "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz",
       "integrity": "sha1-2fGJnq1mRFndi2sMkmrHHPvXvHo=",
       "requires": {
-        "md5": "^2.0.0"
+        "md5": "2.2.1"
       }
     },
     "webpack-sources": {
@@ -16571,8 +20736,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "requires": {
-        "source-list-map": "~0.1.7",
-        "source-map": "~0.5.3"
+        "source-list-map": "0.1.8",
+        "source-map": "0.5.7"
       }
     },
     "webpack-stats-plugin": {
@@ -16589,8 +20754,8 @@
         "chalk": "1.1.3",
         "commander": "2.9.0",
         "common-tags": "0.1.1",
-        "cross-env": "^3.1.1",
-        "find-node-modules": "^1.0.1",
+        "cross-env": "3.2.4",
+        "find-node-modules": "1.0.4",
         "joi": "9.0.0-0",
         "lodash": "4.11.1",
         "npmlog": "2.0.3",
@@ -16608,9 +20773,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "common-tags": {
@@ -16618,7 +20783,7 @@
           "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-0.1.1.tgz",
           "integrity": "sha1-2JNIbsxt8iz/5sOTyIwS9x5+iHE=",
           "requires": {
-            "babel-runtime": "^6.6.1"
+            "babel-runtime": "6.26.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -16626,7 +20791,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isemail": {
@@ -16639,11 +20804,11 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.0-0.tgz",
           "integrity": "sha1-p8pCGWAhSa4Np6fFyh1j08eeCWs=",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "moment": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "moment": "2.22.2",
+            "topo": "2.0.2"
           }
         },
         "load-json-file": {
@@ -16651,11 +20816,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "lodash": {
@@ -16668,7 +20833,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "path-type": {
@@ -16676,9 +20841,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -16691,9 +20856,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -16701,8 +20866,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "set-blocking": {
@@ -16715,9 +20880,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -16725,7 +20890,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "window-size": {
@@ -16738,19 +20903,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
           "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.2",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -16758,8 +20923,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -16769,8 +20934,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.13",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -16804,7 +20969,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -16822,7 +20987,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "2.1.1"
       }
     },
     "widest-line": {
@@ -16830,7 +20995,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
@@ -16848,8 +21013,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -16857,7 +21022,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -16865,9 +21030,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -16897,9 +21062,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -16907,8 +21072,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
       "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
       "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
+        "safe-buffer": "5.0.1",
+        "ultron": "1.1.1"
       },
       "dependencies": {
         "safe-buffer": {
@@ -16938,10 +21103,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xml-parse-from-string": {
@@ -16954,8 +21119,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -16988,7 +21153,7 @@
       "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.4.0.tgz",
       "integrity": "sha1-Sq5EfRPBqnOpidiipTCbCxo8o1M=",
       "requires": {
-        "js-yaml": "^3.5.2"
+        "js-yaml": "3.7.0"
       }
     },
     "yargs": {
@@ -16996,18 +21161,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
       },
       "dependencies": {
         "find-up": {
@@ -17015,7 +21180,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -17025,7 +21190,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
@@ -17033,8 +21198,8 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     },
     "yeast": {
@@ -17047,22 +21212,22 @@
       "resolved": "https://registry.npmjs.org/yurnalist/-/yurnalist-0.2.1.tgz",
       "integrity": "sha1-LTK5YYq2SRiRwTG9kKUpXhn9S60=",
       "requires": {
-        "chalk": "^1.1.1",
-        "death": "^1.0.0",
-        "debug": "^2.2.0",
-        "detect-indent": "^5.0.0",
-        "inquirer": "^3.0.1",
-        "invariant": "^2.2.0",
-        "is-builtin-module": "^1.0.0",
-        "is-ci": "^1.0.10",
-        "leven": "^2.0.0",
-        "loud-rejection": "^1.2.0",
-        "node-emoji": "^1.0.4",
-        "object-path": "^0.11.2",
-        "read": "^1.0.7",
-        "rimraf": "^2.5.0",
-        "semver": "^5.1.0",
-        "strip-bom": "^3.0.0"
+        "chalk": "1.1.3",
+        "death": "1.1.0",
+        "debug": "2.6.9",
+        "detect-indent": "5.0.0",
+        "inquirer": "3.3.0",
+        "invariant": "2.2.4",
+        "is-builtin-module": "1.0.0",
+        "is-ci": "1.1.0",
+        "leven": "2.1.0",
+        "loud-rejection": "1.6.0",
+        "node-emoji": "1.8.1",
+        "object-path": "0.11.4",
+        "read": "1.0.7",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "detect-indent": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-netlify-cms": "^1.0.9",
     "gatsby-plugin-react-helmet": "^2.0.5",
     "gatsby-plugin-sass": "^1.0.17",
+    "gatsby-plugin-segment-js": "^2.0.1",
     "gatsby-plugin-sharp": "^1.6.34",
     "gatsby-remark-images": "^1.5.50",
     "gatsby-source-filesystem": "^1.5.23",

--- a/src/components/navigation/LinkTrack.js
+++ b/src/components/navigation/LinkTrack.js
@@ -1,4 +1,14 @@
 import React from "react";
 import Link from "gatsby-link";
 
-export default class LinkTrack extends React.Component {}
+export default props => {
+  const { to, analytics, ...other } = props;
+  const track = () => {
+    console.log("to", to);
+    console.log("refer", document.referrer);
+    analytics
+      ? analytics.page({ path: to, referrer: document.referrer, ...analytics })
+      : null;
+  };
+  return <Link to={to} {...other} onClick={track} />;
+};

--- a/src/components/navigation/LinkTrack.js
+++ b/src/components/navigation/LinkTrack.js
@@ -2,11 +2,8 @@ import React from "react";
 import Link from "gatsby-link";
 
 export default props => {
-  const { to, analytics, ...other } = props;
   const track = () => {
-    analytics
-      ? analytics.page({ path: to, referrer: document.referrer, ...analytics })
-      : null;
+    analytics ? analytics.page() : null;
   };
-  return <Link to={to} {...other} onClick={track} />;
+  return <Link {...props} onClick={track} />;
 };

--- a/src/components/navigation/LinkTrack.js
+++ b/src/components/navigation/LinkTrack.js
@@ -1,0 +1,4 @@
+import React from "react";
+import Link from "gatsby-link";
+
+export default class LinkTrack extends React.Component {}

--- a/src/components/navigation/LinkTrack.js
+++ b/src/components/navigation/LinkTrack.js
@@ -4,8 +4,6 @@ import Link from "gatsby-link";
 export default props => {
   const { to, analytics, ...other } = props;
   const track = () => {
-    console.log("to", to);
-    console.log("refer", document.referrer);
     analytics
       ? analytics.page({ path: to, referrer: document.referrer, ...analytics })
       : null;

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -1,51 +1,69 @@
-import React from 'react'
-import Link from 'gatsby-link'
-import logo from '../../img/sw_logo.png'
-import animation from './animation.js'
+import React from "react";
+import Link from "gatsby-link";
+import logo from "../../img/sw_logo.png";
+import animation from "./animation.js";
+import LinkTrack from "./LinkTrack.js";
 
 export default class Navbar extends React.Component {
   render() {
     return (
-      <aside className="custom_scroll menu column is-2-desktop is-3-tablet is-hidden-touch navbar is-fixed-top" id="side_nav">
-        <Link to="/#home_hero" className="logo_wrapper" onClick={animation.spinLogo}>
-          <img id="sw_logo" src={logo} alt="scholars_way_logo"/>
+      <aside
+        className="custom_scroll menu column is-2-desktop is-3-tablet is-hidden-touch navbar is-fixed-top"
+        id="side_nav"
+      >
+        <Link
+          to="/#home_hero"
+          className="logo_wrapper"
+          onClick={animation.spinLogo}
+        >
+          <img id="sw_logo" src={logo} alt="scholars_way_logo" />
         </Link>
-        <hr className="nav_hr"/>
-        <p className="menu-label">
-          Sholars Ways
-        </p>
+        <hr className="nav_hr" />
+        <p className="menu-label">Sholars Ways</p>
         <ul className="menu-list">
-          <li>        
-            <Link to="/about">
-              About
-            </Link>
+          <li>
+            <Link to="/about">About</Link>
           </li>
         </ul>
-        <hr className="nav_hr"/>
-        <p className="menu-label">
-          Clinic
-        </p>
+        <hr className="nav_hr" />
+        <p className="menu-label">Clinic</p>
         <ul className="menu-list">
-          <li><Link to="/clinic/practitioner">Practitioners</Link></li>
-          <li><Link to="/clinic/expertise">Expertise</Link></li>
-          <li><Link to="/clinic/appointment">Appointment</Link></li>
+          <li>
+            <Link to="/clinic/practitioner">Practitioners</Link>
+          </li>
+          <li>
+            <Link to="/clinic/expertise">Expertise</Link>
+          </li>
+          <li>
+            <Link to="/clinic/appointment">Appointment</Link>
+          </li>
         </ul>
-        <hr className="nav_hr"/>
-        <p className="menu-label">
-          Training
-        </p>
+        <hr className="nav_hr" />
+        <p className="menu-label">Training</p>
         <ul className="menu-list">
-          <li><Link to="/class">Classes</Link></li>
-          <li><Link to="/class/schedule">Schedule</Link></li>
+          <li>
+            <Link to="/class">Classes</Link>
+          </li>
+          <li>
+            <Link to="/class/schedule">Schedule</Link>
+          </li>
         </ul>
-        <hr className="nav_hr"/>
+        <hr className="nav_hr" />
         <ul className="menu-list">
-          <li><Link to="/library">Library</Link></li>
-          <li><Link to="/blog">Blog</Link></li>
-          <li><Link to="/contact">Join Us</Link></li>
-          <li><Link to="/products">Products</Link></li>
+          <li>
+            <Link to="/library">Library</Link>
+          </li>
+          <li>
+            <Link to="/blog">Blog</Link>
+          </li>
+          <li>
+            <Link to="/contact">Join Us</Link>
+          </li>
+          <li>
+            <Link to="/products">Products</Link>
+          </li>
         </ul>
       </aside>
-    )
+    );
   }
 }

--- a/src/components/navigation/Navbar.js
+++ b/src/components/navigation/Navbar.js
@@ -11,56 +11,56 @@ export default class Navbar extends React.Component {
         className="custom_scroll menu column is-2-desktop is-3-tablet is-hidden-touch navbar is-fixed-top"
         id="side_nav"
       >
-        <Link
+        <LinkTrack
           to="/#home_hero"
           className="logo_wrapper"
           onClick={animation.spinLogo}
         >
           <img id="sw_logo" src={logo} alt="scholars_way_logo" />
-        </Link>
+        </LinkTrack>
         <hr className="nav_hr" />
         <p className="menu-label">Sholars Ways</p>
         <ul className="menu-list">
           <li>
-            <Link to="/about">About</Link>
+            <LinkTrack to="/about">About</LinkTrack>
           </li>
         </ul>
         <hr className="nav_hr" />
         <p className="menu-label">Clinic</p>
         <ul className="menu-list">
           <li>
-            <Link to="/clinic/practitioner">Practitioners</Link>
+            <LinkTrack to="/clinic/practitioner">Practitioners</LinkTrack>
           </li>
           <li>
-            <Link to="/clinic/expertise">Expertise</Link>
+            <LinkTrack to="/clinic/expertise">Expertise</LinkTrack>
           </li>
           <li>
-            <Link to="/clinic/appointment">Appointment</Link>
+            <LinkTrack to="/clinic/appointment">Appointment</LinkTrack>
           </li>
         </ul>
         <hr className="nav_hr" />
         <p className="menu-label">Training</p>
         <ul className="menu-list">
           <li>
-            <Link to="/class">Classes</Link>
+            <LinkTrack to="/class">Classes</LinkTrack>
           </li>
           <li>
-            <Link to="/class/schedule">Schedule</Link>
+            <LinkTrack to="/class/schedule">Schedule</LinkTrack>
           </li>
         </ul>
         <hr className="nav_hr" />
         <ul className="menu-list">
           <li>
-            <Link to="/library">Library</Link>
+            <LinkTrack to="/library">Library</LinkTrack>
           </li>
           <li>
-            <Link to="/blog">Blog</Link>
+            <LinkTrack to="/blog">Blog</LinkTrack>
           </li>
           <li>
-            <Link to="/contact">Join Us</Link>
+            <LinkTrack to="/contact">Join Us</LinkTrack>
           </li>
           <li>
-            <Link to="/products">Products</Link>
+            <LinkTrack to="/products">Products</LinkTrack>
           </li>
         </ul>
       </aside>


### PR DESCRIPTION
`Link` components are wrapped with `LinkTrack` component which has a built in page tracking

Haven't tested or debugged in production yet.  You can go to Segment website, and look under 'Scholars Way Dev' to see the events if they are tracking or not. 

Then click on the 'Google Analytics' destination and you can set up the GA dashboard integration.

Cannot test it locally because the api call to download the tracking library is blocked.  Have to test in production for now.  

All current trackers are in a throwaway Segment 'source' named 'Scholars Way Dev' so real data is not polluted when site is about to launch.